### PR TITLE
Remove X-Forwarded-Proto limitation from docs

### DIFF
--- a/enabling-https-to-routers.html.md.erb
+++ b/enabling-https-to-routers.html.md.erb
@@ -14,10 +14,7 @@ Securing the connection between the load balancer and CF router will also enable
 
 ### TLS Pass-Through
 
-<p class='note'><strong>Note</strong>: This is the recommended approach.
-  <br>
-  <strong>Note</strong>: The CF router will not append the header <code>X-Forwarded-Proto</code>, which means applications will not receive any information about the protocol of the original request. This will be addressed in a future release.
-</p>
+<p class='note'><strong>Note</strong>: This is the recommended approach.</p>
 
 This approach allows the load balancer to not terminate TLS for Cloud Foundry domains at all, instead passing through the underlying TCP connection to the CF router. This is the more performant option, establishing and terminating a single TLS connection. The certificate on the CF router must be associated with the correct hostname so that HTTPS can validate the request, and signed by a trusted Certificate Authority.
 


### PR DESCRIPTION
This PR is to remove the limitation of "X-Forwarded-Proto" not being included in the request from gorouter to apps. If "X-Forwarded-Proto" is not present in the request to gorouter then it will include it in the request to app by using the scheme with which the request was made to gorouter.

Regards,
@atulkc and @ishustava

Pivotal tracker story link: https://www.pivotaltracker.com/story/show/105895048