### PR TITLE
Removed extra comma in rule example

### DIFF
--- a/app-sec-groups.html.md.erb
+++ b/app-sec-groups.html.md.erb
@@ -51,7 +51,7 @@ describe the rules. Refer to the example below:
 	            "log": true,
 	            "ports": "80-443",
 	            "protocol": "tcp"
-	        },
+	        }
 	]
 	```
 	This rules file allows ICMP traffic of code 1 and type 0 to all destinations, and TCP traffic to 10.0.11.0/24 on ports 80-443.<br/><br/>


### PR DESCRIPTION
Extra comma in rule example causes `cf create-security-group` command to fail -- for which this is supposed to be an example.