### PR TITLE
Fix indentation on documentation

### DIFF
--- a/quota-plans.html.md.erb
+++ b/quota-plans.html.md.erb
@@ -78,7 +78,7 @@ editing the manifest.
 1. In a terminal window, run `bosh edit deployment` to open the deployment manifest YAML file in your default text editor.
 1. Search for `quota_definitions`.
 1. Add a new quota definition with values that you specify. Use the default quota definition as a formatting template. The following example shows the `quota_definitions` portion of the `cf.yml` manifest after adding the `silver_quota` plan:
-  <pre class='terminal'>
+<pre class='terminal'>
   quota\_definitions:
     default:
       memory\_limit: 10240M
@@ -92,7 +92,7 @@ editing the manifest.
       total\_routes: 500
       total\_services: 25
       trial\_db\_allowed: true
-  </pre>
+</pre>
 
 1. Save and close the deployment manifest.
 


### PR DESCRIPTION
'quota_definitions' currently shows up at the same level as 'default' and 'silver_quota'