### PR TITLE
Fix example call output of cf diego-apps

### DIFF
--- a/apps-enable-diego.html.md.erb
+++ b/apps-enable-diego.html.md.erb
@@ -251,7 +251,7 @@ To verify a successful migration of your apps from DEA to Diego, perform the fol
     <pre class="terminal">
     $ cf dea-apps -o MY-ORG
 
-    Getting apps on the DEA runtime as example_user...
+    Getting apps on the DEA runtime in org MY-ORG as example_user...
     OK
 
     name        org     space
@@ -263,7 +263,7 @@ To verify a successful migration of your apps from DEA to Diego, perform the fol
     <pre class="terminal">
     $ cf diego-apps -o MY-ORG
 
-    Getting apps on the DEA runtime as example_user...
+    Getting apps on the Diego runtime in org MY-ORG as example_user...
     OK
 
     name        org     space


### PR DESCRIPTION
The command ``cf diego-apps -o MY-ORG`` outputs

```
Getting apps on the Diego runtime [...]
```

However, the documentation says

```
Getting apps on the DEA runtime [...]
```
