### PR TITLE
Add documentation for configuring load balancers

### DIFF
--- a/configure-lb-healthcheck.html.erb
+++ b/configure-lb-healthcheck.html.erb
@@ -7,17 +7,19 @@ owner: Routing
 
 ## Configuring Load Balancer Healthchecks for CF Routers
 
-The following are the default healthcheck endpoints that are available for haproxy, gorouter, and tcp_router:
-  * `http://haproxy_IP:8080/health` (This is the HAProxy deployed with CF-Release)
-  * `http://gorouter_IP:8080/health`
-  * `http://tcp_router_IP:80/health`
+In environments where high availability is required operators should configure their own redundant load balancer to forward traffic directly to the CF routers. In environments where high-availabilty is not required you can skip the load balancer; configure DNS to resolve the CF domains directly to a single instance of a router.  
 
-For gorouter the healthcheck port is configurable with the cf-release deployment manifest
+To make sure your load balancer only forwards requests to router instances that are healthy, configure your load balancer to use the following HTTP healthcheck endpoints. Be sure to add the IP addresses of all router instances along with their corresponding port and path. 
+
+  * HTTP Router (aka "Gorouter"): `http://gorouter_IP:8080/health`
+  * TCP Router: `http://tcp_router_IP:80/health`
+
+For Gorouter the healthcheck port is configurable with the cf-release deployment manifest
 property `router.status.port` in cf-release.
 
-For tcp_router the healthcheck port is configurable with the routing-release deployment manifest
+For TCP Router the healthcheck port is configurable with the routing-release deployment manifest
 property `haproxy.health_check_port`. This property will not affect the healthcheck of the HAProxy deployed with CF-Release.
 
-In your load balancer backend health configuration,
-be sure to add the running instances of your selected type of router,
-set their corresponding ports, and set the request paths as `/health`.
+The HAProxy that comes with cf-release is an optional component that can be helpful in specific scenarios. E.g. when CF is deployed on Google Cloud, having a tier of HAProxy instances behind Google's load balancer and in front of the Gorouters can remove the need for configuring an additional Google load balancer to serve SSH requests to Diego containers.
+
+ * HAProxy (in cf-release): `http://haproxy_IP:8080/health`

--- a/configure-lb-healthcheck.html.erb
+++ b/configure-lb-healthcheck.html.erb
@@ -1,0 +1,23 @@
+---
+title: Configuring Load Balancer Healthchecks for Cloud Foundry Routers
+owner: Routing
+---
+
+<strong><%= modified_date %></strong>
+
+## Configuring Load Balancer Healthchecks for CF Routers
+
+The following are the default healthcheck endpoints that are available for haproxy, gorouter, and tcp_router:
+  * `http://haproxy_IP:8080/health` (This is the HAProxy deployed with CF-Release)
+  * `http://gorouter_IP:8080/health`
+  * `http://tcp_router_IP:80/health`
+
+For gorouter the healthcheck port is configurable with the cf-release deployment manifest
+property `router.status.port` in cf-release.
+
+For tcp_router the healthcheck port is configurable with the routing-release deployment manifest
+property `haproxy.health_check_port`. This property will not affect the healthcheck of the HAProxy deployed with CF-Release.
+
+In your load balancer backend health configuration,
+be sure to add the running instances of your selected type of router,
+set their corresponding ports, and set the request paths as `/health`.

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -31,3 +31,4 @@ title: Administering and Operating Cloud Foundry
 * <a href="./hm-notifications.html" class="subnav">Configuring Health Monitor Notifications</a>
 * <a href="./enabling-tcp-routing.html" class="subnav">Enabling TCP Routing</a>
 * <a href="./supporting-websockets.html" class="subnav">Supporting WebSockets</a>
+* <a href="./configure-lb-healthcheck.html" class="subnav">Configuring Load Balancer Healthchecks for Cloud Foundry</a>


### PR DESCRIPTION
Hi, 

This PR adds documentation for operators to configure Load balancers to CF deployment. This covers the below 3 cases

1. Configure LB infront of Haproxy
1. Configure LB infront of gorouter
1. Configure LB infront of TCP router

Regards
Shash && Swetha
CF routing team
