### PR TITLE
Update enabling-tcp-routing.html.md.erb

### DIFF
--- a/enabling-tcp-routing.html.md.erb
+++ b/enabling-tcp-routing.html.md.erb
@@ -83,9 +83,9 @@ In [Post-Deployment Steps](#configure-domain), we describe that in order to crea
 
 After deployment, you can modify the range of ports available for TCP routes using `cf curl` commands, as demonstrated with the commands below. These commands require an admin user with the `routing.router_groups.read` and `routing.router_groups.write` scopes.
 
-1. In a terminal window, run `cf curl /routing/v1/router-groups` to view the `reservable_ports`:
+1. In a terminal window, run `cf curl /routing/v1/router_groups` to view the `reservable_ports`:
   <pre class="terminal"> 
-  $ cf curl /routing/v1/router-groups
+  $ cf curl /routing/v1/router_groups
     [
       {
         "guid": "9d1c1da9-ed63-45e8-45ee-256f8579455c",


### PR DESCRIPTION
This PR changes `cf curl /routing/v1/router-groups` to `cf curl /routing/v1/router_groups`

We noticed confusion in people following these docs where `cf curl /routing/v1/router-groups` returns a 404. This fixes this typo in the docs.

If there are other actively maintained branches on this repo, could you make the same change on those branches too? Or we could submit separate PRs for those branches if you let us know which branches also need the change.

- Edwin and @aaronshurley