### PR TITLE
remove links to docker plugin for cf CLI <v6.13.0

### DIFF
--- a/docker.html.md.erb
+++ b/docker.html.md.erb
@@ -105,13 +105,7 @@ $ cf disable-feature-flag diego_docker
 ##<a id='push-docker'></a>Push a Docker Image with the cf CLI
 
 Follow these instructions to deploy updated or new Docker images using the 
-Cloud Foundry Command Line Interface (cf CLI).
-
-To perform the procedures in this topic, you must install cf CLI v6.13.0 or 
-later. 
-For more information about installing the cf CLI, see the [Installing the cf CLI](../cf-cli/install-go-cli.html) topic.
-For information about pushing a Docker image with a previous version of the cf 
-CLI, see [Docker Support in CF + Diego](https://github.com/cloudfoundry-incubator/diego-design-notes/blob/master/docker-support.md).
+[Cloud Foundry Command Line Interface (cf CLI)](../cf-cli/install-go-cli.html).
 
 When pushing an app, you specify either a Docker image on Docker Hub or the URI 
 to a trusted Docker registry. 


### PR DESCRIPTION
cf CLI 6.13.0 was released in Oct 2015. Not likely anyone is on an older version and wants to use the plugin.
If anyone is still on such an older version, they'll get an error that the flag doesn't exist and probably figure out it's time to upgrade their CLI.