### PR TITLE
Use --docker-image instead of -o for clarity

### DIFF
--- a/docker.html.md.erb
+++ b/docker.html.md.erb
@@ -114,7 +114,7 @@ Also, when using Diego, you must use a registry that supports the [Docker Regist
 
 ###<a id='public'></a>Push a Docker Image Using Docker Hub
 
-Run `cf push test-app -o cloudfoundry/MY-DOCKER-IMAGE` to deploy a Docker 
+Run `cf push test-app --docker-image cloudfoundry/MY-DOCKER-IMAGE` to deploy a Docker 
 image. 
 Replace `MY-DOCKER-IMAGE` with the name of an image from an accessible Docker 
 Registry.
@@ -122,13 +122,13 @@ Registry.
 For example, the following command pushes the `test-app` on Docker Hub to Cloud 
 Foundry:
 
-<pre class='terminal'>$ cf push test-app -o cloudfoundry/test-app</pre>
+<pre class='terminal'>$ cf push test-app --docker-image cloudfoundry/test-app</pre>
 
 ###<a id='private'></a>Push a Docker Image Using Docker Trusted Registries
 
 To deploy a Docker image using Docker trusted registries, run:
 
-<pre class='terminal'>$ cf push my-app -o MY-PRIVATE-REGISTRY.DOMAIN:5000/image/name:v2
+<pre class='terminal'>$ cf push my-app --docker-image MY-PRIVATE-REGISTRY.DOMAIN:5000/image/name:v2
 </pre>
 
 Replace `MY-PRIVATE-REGISTRY.DOMAIN` with your domain name, which resolves to 


### PR DESCRIPTION
We found in usability testing that people who were pushing a Docker image for
the first time were confused by the -o option in the examples. It took them a
while to work out what it meant.

First time users don't understand how the thing works and come with all sorts
of ideas about how it *might* work. For example. one participant wondered if CF
might accept a github repository name and look for a Dockerfile in it to build
an image. This is a reasonable hypothesis, consistent with previous
experience of CF from the buildpack lifecycle.

The -o option doesn't give them any clues that their hypothesis about how it
works is incorrect.

Change it to the long --docker-image argument to try to make it more explicit.