### PR TITLE
Update isolation-segments.html.md.erb

### DIFF
--- a/isolation-segments.html.md.erb
+++ b/isolation-segments.html.md.erb
@@ -342,7 +342,7 @@ You set the default isolation segment for an org by sending a request to the end
 curl "https\://api.example.org/v2/organizations/45a66ed9-cb76-46c3-92dd-b29187b50bfb" \
   -X PUT \
   -H "Authorization: bearer 7h15154l0n64lph4num3r1c57r1n6" \
-  -d '{ \
+  -d '{
     "default_isolation_segment_guid":"323f211e-fea3-4161-9bd1-615392327913" \
   }'
 </pre>
@@ -359,7 +359,7 @@ You add a space to an isolation segment by sending a request to the endpoint for
 curl "https\://api.example.org/v2/spaces/68d54d31-9b3a-463b-ba94-e8e4c32edbac" \
   -X PUT \
   -H "Authorization: bearer 7h15154l0n64lph4num3r1c57r1n6" \
-  -d '{ \
+  -d '{
     "isolation_segment_guid":"323f211e-fea3-4161-9bd1-615392327913" \
   }'
 </pre>


### PR DESCRIPTION
Typo in the curl request examples. No need for escaping newlines with '\' 
inside single quotes in the shell.