### PR TITLE
System-up critical state should be true

### DIFF
--- a/notifications.html.md.erb
+++ b/notifications.html.md.erb
@@ -66,7 +66,7 @@ You must register a notification before sending it. Using the token `notificatio
 $ uaac curl https://notifications.user.example.com/notifications -X PUT --data '{  "source_name": "Cloud Ops Team",
   "notifications": {
      "system-going-down": {"critical": true, "description": "Cloud going down" },
-     "system-up": { "critical": false, "description": "Cloud back up" }
+     "system-up": { "critical": true, "description": "Cloud back up" }
      }
  }'
 </pre>


### PR DESCRIPTION
From description on line 76
`system-going-down` and `system-up` are made `critical`, so no users can unsubscribe from that notification , 

##### Changes
- system-up critical state is false in docs , should be true