### PR TITLE
changed to be more end-user focused

### DIFF
--- a/isolation-segments.html.md.erb
+++ b/isolation-segments.html.md.erb
@@ -18,7 +18,7 @@ Target the API endpoint of your deployment with `cf api` and log in with `cf log
 
 <%= vars.isolation_segments_intro %>
 
-After an admin creates a new isolation segment, the admin can then create and manage relationships between the orgs and spaces of a Cloud Foundry deployment and the new isolation segment object.
+After an admin creates a new isolation segment, the admin can then create and manage relationships between the orgs and spaces of a Cloud Foundry deployment and the new isolation segment.
 
 To manage the isolation segment, an operator uses cf CLI commands.
 


### PR DESCRIPTION
it's an isolation segment object to CAPI, but it's an isolation segment to end-users