### PR TITLE
removed incorrect statement

### DIFF
--- a/isolation-segments.html.md.erb
+++ b/isolation-segments.html.md.erb
@@ -83,8 +83,6 @@ Creating isolation segment my_segment as admin...
 OK
 </pre>
 
-The command returns an error message if another isolation segment with the same name exists.
-
 ## <a id="lists"></a> Retrieve Isolation Segment Information
 
 The `cf isolation-segments`, `cf org`, and `cf space` commands retrieve information about isolation segments. The isolation segments you can see depends on your role, as follows:


### PR DESCRIPTION
cli does not fail when specifying an existing isolation segment.