### PR TITLE
Update Gorouter Retry Behavior Table

### DIFF
--- a/routing-keepalive.html.md.erb
+++ b/routing-keepalive.html.md.erb
@@ -33,8 +33,8 @@ When you deploy an app that requires Diego cells to restart or recreate, the app
     <td>cannot establish a TCP connection to the routing backend for the app</td>
     <td>waits 15 minutes for a response.</td>
   </tr><tr>
-    <td>retries the request three times.</td>
     <td>establishes a TCP connection to the routing backend, but the app does not respond</td>
+    <td>retries the request three times.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
The contents of the Gorouter Retry Behavior Table are out of order.
The correct expression should be 'If the connection is a TCP connection to the routing backend, but the app does not respond, then Gorouter retries the request three times.'