### PR TITLE
Mention that custom stacks must use tarred rootfs

### DIFF
--- a/custom-stack.html.md.erb
+++ b/custom-stack.html.md.erb
@@ -19,17 +19,17 @@ The following example adds a new Linux-based `pancakes` stack for use with the [
 
 Stacks exist in a subdirectory on their host machine, typically under `/var/vcap/packages` or `/var/vcap/data`. Your BOSH job template must deploy the stack onto a host machine, and provide lifecycle binaries that work with your stack. The lifecycle binaries for your stack are helper programs that stage and run apps on the stack file system. To create a `pancakes-release` job template that deploys a custom stack, follow these steps:
 
-1. [Create a BOSH release](http://bosh.io/docs/create-release.html) `pancakes-release` for a job template that expands a stack into place in its subdirectory. For example, a `pancakes-rootfs` template might create a full Linux root file system in the directory `/var/vcap/packages/pancakes-rootfs/rootfs`. See the [‘rootfses’ job template in diego-release](https://github.com/cloudfoundry/cflinuxfs2-release/tree/master/jobs/cflinuxfs2-rootfs-setup) for one way to do this.
+1. [Create a BOSH release](http://bosh.io/docs/create-release.html) `pancakes-release` for a job template that expands a stack into place in its subdirectory. The rootfs must be packaged as a `.tar` file, for example, a `pancakes-rootfs` template might create a tarred full Linux root file system at `/var/vcap/packages/pancakes-rootfs/rootfs.tar`. See the [‘rootfses’ job template in diego-release](https://github.com/cloudfoundry/cflinuxfs2-release/tree/master/jobs/cflinuxfs2-rootfs-setup) for one way to do this.
 
 1. Create lifecycle binaries for your stack. See the diego-release repository for examples of app lifecycle binary source code:
   * [Buildpack App Lifecycle](https://github.com/cloudfoundry-incubator/diego-release/tree/develop/packages/buildpack_app_lifecycle)
   * [Docker App Lifecycle](https://github.com/cloudfoundry-incubator/diego-release/tree/develop/packages/docker_app_lifecycle)
-  * [Windows App Lifecycle](https://github.com/cloudfoundry-incubator/diego-release/tree/develop/packages/windows_app_lifecycle)  
+  * [Windows App Lifecycle](https://github.com/cloudfoundry-incubator/diego-release/tree/develop/packages/windows_app_lifecycle)
 
 1. Generate a gzipped tar archive of the lifecycle binaries, `pancakes-app-lifecycle.tgz`.
 
 1. Create a dummy `pancakes-app-lifecycle` job template as a package within `pancakes-release`. Include the `pancakes-app-lifecycle.tgz` file in the job template directory.
-<p class="note"><strong>Note</strong>: The `pancakes-app-lifecycle` job template does not need to run any process of its own.</p> 
+<p class="note"><strong>Note</strong>: The `pancakes-app-lifecycle` job template does not need to run any process of its own.</p>
 
 1. List the dummy `pancakes-app-lifecycle` job as a dependency in the `pancakes-release` spec file. This makes BOSH publish the lifecycle binaries to `/var/vcap/packages` for inclusion in any cells that use the `pancakes` stack.
 
@@ -52,7 +52,7 @@ Stacks exist in a subdirectory on their host machine, typically under `/var/vcap
       &#45; name: metron_agent
         release: cf
     </pre>
-  
+
 1. Add `pancakes-app-lifecycle` to the `base_job_templates` list under the `file_server` Diego job. In [diego-release](https://github.com/cloudfoundry-incubator/diego-release), the `file_server` job resides in the `access` job template group. For example, add the lines shown in **bold** to the following list of job templates:
 
     <pre>
@@ -69,11 +69,11 @@ Stacks exist in a subdirectory on their host machine, typically under `/var/vcap
        release: pancakes</strong>
     </pre>
 
-1. The `diego.rep.preloaded_rootfses` property of the Cell Rep holds an array associating stacks with their file system root locations. Add a pair to this list to associate the `pancakes` stack with its file system root location, set up on the cell by the `pancakes-rootfs` job. For example, in the `preloaded_rootfses:` property under `rep:` in your [Diego manifest](https://github.com/cloudfoundry-incubator/diego-release), set the array to the following by adding the text shown in **bold**:
+1. The `diego.rep.preloaded_rootfses` property of the Cell Rep holds an array associating stacks with the location of their tarred rootfs in the filesystem. Add a pair to this list to associate the `pancakes` stack with its file system root location, set up on the cell by the `pancakes-rootfs` job. For example, in the `preloaded_rootfses:` property under `rep:` in your [Diego manifest](https://github.com/cloudfoundry-incubator/diego-release), set the array to the following by adding the text shown in **bold**:
 
     <pre>
-      ["cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs",
-      <b>"pancakes:/var/vcap/packages/pancakes-rootfs/rootfs"</b>]
+      ["cflinuxfs2:/var/vcap/packages/cflinuxfs2/rootfs.tar",
+      <b>"pancakes:/var/vcap/packages/pancakes-rootfs/rootfs.tar"</b>]
     </pre>
 
 1. Configure the stager and nsync components to use the `pancakes` lifecycle binary bundle to start and stop apps running on the `pancakes` stack. For example, in [CAPI release](https://github.com/cloudfoundry/capi-release), add the line shown in **bold** to the `default` list under the manifest definitions for both `diego.nsync.lifecycle_bundles` and `diego.stager.lifecycle.bundles`:


### PR DESCRIPTION
I want to update this custom stack doc for the changeover to using GrootFS as the Garden Image Plugin. This change means that rootfses must be packaged as `.tar` files.

I'm not sure in OSS CF docs if there is a convention for documenting older information as well (garden-shed will be unsupported as soon as we can make this happen). Should we have a section here for how this would work with the old garden-shed as well as Groot?