### PR TITLE
add service_instance_sharing feature flag

### DIFF
--- a/listing-feature-flags.html.md.erb
+++ b/listing-feature-flags.html.md.erb
@@ -30,6 +30,7 @@ To perform the following procedures, you must be logged in to your deployment as
     env_var_visibility                     enabled
     space_scoped_private_broker_creation   enabled
     space_developer_env_var_visibility     enabled
+    service_instance_sharing               disabled
     </pre>
     <br>
     For descriptions of the features enabled by each feature flag, see the [Feature Flags](#flags) section below.
@@ -80,6 +81,7 @@ each flag, and the minimum Cloud Controller API (CC API) version necessary to us
 * `env_var_visibility`: All users can view environment variables. Minimum CC API version: 2.58.
 * `space_scoped_private_broker_creation`: Space Developers can create space-scoped private service brokers. Minimum CC API version: 2.58.
 * `space_developer_env_var_visibility`: Space Developers can view their v2 environment variables. Org Managers and Space Managers can view their v3 environment variables. Minimum CC API version: 2.58.
+* `service_instance_sharing`: Space Developers can share service instances between two spaces (across orgs) in which they have the Space Developer role.
 
 For more information about feature flag commands, see the **Feature Flags** 
 section of the [Cloud Foundry API documentation](http://apidocs.cloudfoundry.org).


### PR DESCRIPTION
This is a new feature flag in Cloud Foundry that allows developers to share service instances across spaces (in any orgs) that they have the SpaceDeveloper role in.