### PR TITLE
Please review before merging: Fix 'Add a Buildpack' HTML id

### DIFF
--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -13,7 +13,7 @@ If your application uses a language or framework that the Cloud Foundry system b
 * Use a [Cloud Foundry Community Buildpack](https://github.com/cloudfoundry-community/cf-docs-contrib/wiki/Buildpacks)
 * Use a [Heroku Third-Party Buildpack](https://devcenter.heroku.com/articles/third-party-buildpacks)
 
-## <a id="disabling-custom-buildpacks"></a>Add a Buildpack ##
+## <a id="add"></a>Add a Buildpack ##
 
 <p class="note"><strong>Note</strong>: You must be a Cloud Foundry admin user to run the commands discussed in this section.</p>
 


### PR DESCRIPTION
⚠️ : Please Review before merging: I'm not sure if changing the id of the anchor is sufficient to fix all places where this is referenced. For example, I'm not sure how the TOC at the top of the page comes into existence.

This change is to avoid duplicate ids and especially prevent the 'Disabling Custom Buildpacks' TOC link jump to the 'Add a Buildpack' section.