### PR TITLE
Change stack name

### DIFF
--- a/stack-auditor.html.md.erb
+++ b/stack-auditor.html.md.erb
@@ -9,7 +9,7 @@ This topic describes how to use the Stack Auditor plugin for the Cloud Foundry C
 
 Stack Auditor is a cf CLI plugin that provides commands for listing apps and their stacks, migrating apps to a new stack, and deleting a stack. 
 
-One use case for Stack Auditor is when you must migrate a large number of apps to a new stack. This includes moving from `cflinuxfs2` to `cflinuxfs3` in preparation to upgrade your deployment to a version that does not contain `cflinuxfs3`. The following table describes the workflow you can use:
+One use case for Stack Auditor is when you must migrate a large number of apps to a new stack. This includes moving from `cflinuxfs2` to `cflinuxfs3` in preparation to upgrade your deployment to a version that does not contain `cflinuxfs2`. The following table describes the workflow you can use:
 
 <table>
 	<tr>


### PR DESCRIPTION
One would need this if they were upgrading to a version of the platform that _didn't_ have the stack you were on before.