### PR TITLE
Replace python with jq in the script to calculate disk usage by all active volumes

### DIFF
--- a/examining_grootfs_disk.html.md.erb
+++ b/examining_grootfs_disk.html.md.erb
@@ -197,8 +197,7 @@ You can determine the bytes of all active volumes on disk by running one of the 
 
     ```
     for image in $(ls /var/vcap/data/grootfs/store/unprivileged/meta/dependencies/image\:*.json); \
-    do cat $image | python -c 'import json,sys;obj=json.load(sys.stdin); \
-    print "\n".join(obj)' ; done | sort -u \
+    do cat $image | jq .[] -r; done | sort -u \
     | xargs -I{} cat /var/vcap/data/grootfs/store/unprivileged/meta/volume-{} \
     | cut -d : -f 2 | cut -d} -f1 \
     | awk '{sum += $1} END {print sum}'
@@ -208,8 +207,7 @@ You can determine the bytes of all active volumes on disk by running one of the 
 
     ```
     for image in $(ls /var/vcap/data/grootfs/store/privileged/meta/dependencies/image\:*.json); \
-    do cat $image | python -c 'import json,sys;obj=json.load(sys.stdin); \
-    print "\n".join(obj)' ; done | sort -u \
+    do cat $image | jq .[] -r; done | sort -u \
     | xargs -I{} cat /var/vcap/data/grootfs/store/privileged/meta/volume-{} \
     | cut -d : -f 2 | cut -d} -f1 \
     | awk '{sum += $1} END {print sum}'


### PR DESCRIPTION
I have three reasons to make this PR.

1) `python` is not in `$PATH` in diego cells. I can find Python3 under `/usr/bin/`.
2) Python2 is not installed in diego cells, thus `print "\n".join(obj)` will error out even if customer manages to add `/usr/bin/python3.5` into `$PATH`. 
3) `jq` is installed in diego cells and is in `$PATH`.

Thanks,
Wayne (wchen@pivotal.io)