### PR TITLE
remove legacy firewall port 4443

### DIFF
--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -408,7 +408,7 @@ To configure firewall rules for isolation segment traffic, do the following:
       <tr>
       <td><code>is1-to-shared</code></td>
       <td>Private isolation segment</td>
-      <td><code>tcp:3000,3457,4003<br>4103,4222,4443,8080<br>8082,8083,8443,8844
+      <td><code>tcp:3000,3457,4003<br>4103,4222,8080<br>8082,8083,8443,8844
       	<br>8853,8889,8891<br>9000,9022,9023,9090,9091<br></code>
       <br><br>
       See <a href="#port-reference">Port Reference Table</a> for information about the processes that use these ports and their corresponding manifest properties.


### PR DESCRIPTION
PAS 2.7 removes the syslog_adapter instance_group, so we no longer need to allow traffic from private to shared over port 4443.

https://github.com/pivotal/pas-requests/issues/483