### PR TITLE
Document Diego File Server HTTPS port 8447

### DIFF
--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -408,7 +408,7 @@ To configure firewall rules for isolation segment traffic, do the following:
       <tr>
       <td><code>is1-to-shared</code></td>
       <td>Private isolation segment</td>
-      <td><code>tcp:3000,3457,4003<br>4103,4222,8080<br>8082,8083,8443,8844
+      <td><code>tcp:3000,3457,4003<br>4103,4222,8080<br>8082,8083,8443,8447,8844
       	<br>8853,8889,8891<br>9000,9022,9023,9090,9091<br></code>
       <br><br>
       See <a href="#port-reference">Port Reference Table</a> for information about the processes that use these ports and their corresponding manifest properties.
@@ -499,7 +499,7 @@ See the following table to understand which protocols and ports map to which pro
 <tr>
 <td><code>tcp</code></td>
 <td><code>8080</code></td>
-<td>Diego file server</td>
+<td>Diego file server - HTTP</td>
 <td><code>diego.file_server.listen_addr</code></td>
 </tr>
 <tr>
@@ -519,6 +519,12 @@ See the following table to understand which protocols and ports map to which pro
 <td><code>8443</code></td>
 <td>UAA</td>
 <td><code>uaa.ssl.port</code></td>
+</tr>
+<tr>
+<td><code>tcp</code></td>
+<td><code>8447</code></td>
+<td>Diego file server - HTTPS</td>
+<td><code>file_server.https_listen_addr</code></td>
 </tr>
 <tr>
 <td><code>tcp</code></td>


### PR DESCRIPTION
New feature in PAS 2.7 and above requires traffic between IST and PAS on port 8447

https://github.com/pivotal/pas-requests/issues/486

Formatting on the Port Reference Table could use some love.