### PR TITLE
Refine Prefix section to also apply to annotations

### DIFF
--- a/metadata.html.md.erb
+++ b/metadata.html.md.erb
@@ -153,11 +153,11 @@ The following table describes the requirements for creating annotations.
 	<td><i>n/a</i></td>
 </tr>
 </table>
-### <a id="prefix"></a> Label Prefixes
+### <a id="prefix"></a> Metadata key Prefixes
 
-You can ensure a label key is easily differentiated from other keys by using a prefix. A prefix is a namespacing pattern that helps you more clearly identify resources. Prefixes are in DNS subdomain format: `prefix.example.com`. 
+You can ensure a label/annotation key is easily differentiated from other keys by using a prefix. A prefix is a namespacing pattern that helps you more clearly identify resources. Prefixes are in DNS subdomain format: `prefix.example.com`. 
 
-Consider an example in which you have two scanner tools: one for security and one for compliance. Both tools use a `scanned` label. You can disambiguate between the two tools using a prefix. The security tool can prefix a label with `security.example.com/scanned` and the compliance tool can prefix a label with `compliance.example.com/scanned`.
+Consider an example in which you have two scanner tools: one for security and one for compliance. Both tools use a `scanned` label/annotation. You can disambiguate between the two tools using a prefix. The security tool can prefix a label/annotation with `security.example.com/scanned` and the compliance tool can prefix a label/annotation with `compliance.example.com/scanned`.
 
 
 ## <a id="cf-cli-procedures"></a> cf CLI Procedures


### PR DESCRIPTION
Following CAPI work related to https://github.com/cloudfoundry/cloud_controller_ng/issues/1335, annotations benefit from the same prefix format including DNS subdomain.

/CC @tcdowney