### PR TITLE
Refine metadata alphanumeric format

### DIFF
--- a/metadata.html.md.erb
+++ b/metadata.html.md.erb
@@ -149,7 +149,7 @@ The following table describes the requirements for creating annotations.
 <tr>
 	<td>Value</td>
 	<td>0-5000</td>
-	<td><i>n/a</i></td>
+	<td><i>None (i.e. any unicode character is allowed)</i></td>
 	<td><i>n/a</i></td>
 </tr>
 </table>

--- a/metadata.html.md.erb
+++ b/metadata.html.md.erb
@@ -71,7 +71,7 @@ The following table describes the requirements for creating labels.
 	<td>0-253</td>
 	<td>
 		<ul>
-			<li>Alphanumeric</li>
+			<li>Alphanumeric  ( \[a-z0-9A-Z\] )</li>
 			<li><code>-</code></li>
 			<li><code>.</code></li>
 		</ul>
@@ -85,7 +85,7 @@ The following table describes the requirements for creating labels.
 	<td>Key Name</td>
 	<td>1-63</td>
 	<td><ul>
-			<li>Alphanumeric</li>
+			<li>Alphanumeric  ( \[a-z0-9A-Z\] )</li>
 			<li><code>-</code></li>
 			<li><code>_</code></li>
 			<li><code>.</code></li>
@@ -125,7 +125,7 @@ The following table describes the requirements for creating annotations.
 	<td>0-253</td>
 	<td>
 		<ul>
-			<li>Alphanumeric</li>
+			<li>Alphanumeric ( \[a-z0-9A-Z\] )</li>
 			<li><code>-</code></li>
 			<li><code>.</code></li>
 		</ul>
@@ -139,7 +139,7 @@ The following table describes the requirements for creating annotations.
 	<td>Key Name</td>
 	<td>1-63</td>
 	<td><ul>
-			<li>Alphanumeric</li>
+			<li>Alphanumeric ( \[a-z0-9A-Z\] )</li>
 			<li><code>-</code></li>
 			<li><code>_</code></li>
 			<li><code>.</code></li>


### PR DESCRIPTION
Refine metadata alphanumeric wording with normative regexp inspired from K8S documentation at https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set

/CC @tcdowney 