### PR TITLE
Fix syntax error that was preventing rendering  vars.app_runtime_abbr

### DIFF
--- a/user-accounts-index.html.md.erb
+++ b/user-accounts-index.html.md.erb
@@ -9,7 +9,7 @@ The following topics provide information about managing user accounts and user c
 * [Creating and Managing Users with the UAA CLI (UAAC)](../uaa/uaa-user-management.html)
 <% if vars.platform_code == 'CF' %>
 <% else %>
-* [Creating New %= vars.app_runtime_abbr %> User Accounts](../opsguide/creating-account.html)
-* [Adding Existing SAML or LDAP Users to a %= vars.app_runtime_abbr %> Deployment](../opsguide/external-user-management.html)
+* [Creating New <%= vars.app_runtime_abbr %> User Accounts](../opsguide/creating-account.html)
+* [Adding Existing SAML or LDAP Users to a <%= vars.app_runtime_abbr %> Deployment](../opsguide/external-user-management.html)
 <% end %>
 * [Getting Started with the Notifications Service](notifications.html)


### PR DESCRIPTION
Noticed a slight syntax error in the code that was causing the docs to show `%= vars.app_runtime_abbr %>` rather than the value of that variable.  

![image](https://user-images.githubusercontent.com/227505/69960052-70826b00-1500-11ea-97b2-35981fe61655.png)

Turns out its due to a missing `<` character; which this PR fixes