### PR TITLE
remove cli v7 beta references for GA

### DIFF
--- a/enabling-tcp-routing.html.md.erb
+++ b/enabling-tcp-routing.html.md.erb
@@ -5,7 +5,7 @@ owner: Routing
 
 This topic describes enabling TCP Routing for your <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) deployment. This feature enables developers to run apps that serve requests on non-HTTP TCP protocols. You can use TCP routing to comply with regulatory requirements that require your org to terminate the TLS as close to your apps as possible so that packets are not decrypted before reaching the app level.
 
-<p class="note"><strong>Note:</strong> cf CLI v7 beta does not support TCP routing. Creating TCP routes only applies to cf CLI v6.</p>
+<p class="note"><strong>Note:</strong> cf CLI v7 does not support TCP routing. Creating TCP routes only applies to cf CLI v6.</p>
 
 
 ## <a id="ports"></a> Route Ports
@@ -53,7 +53,7 @@ For more information about the cf CLI, see [Using the Cloud Foundry Command Line
 
 ### <a id="configure-domain"></a> Configure <%= vars.app_runtime_abbr %> with Your TCP Domain
 
-<p class="note"><strong>Note:</strong> cf CLI v7 beta does not support TCP routing or creating shared domains with router groups.</p>
+<p class="note"><strong>Note:</strong> cf CLI v7 does not support TCP routing or creating shared domains with router groups.</p>
 
 After deployment, you must configure <%= vars.app_runtime_abbr %> with the domain that you configured in the pre-deployment step above so developers can create TCP routes from it.
 

--- a/metadata.html.md.erb
+++ b/metadata.html.md.erb
@@ -5,17 +5,6 @@ owner: CAPI/CLI
 
 This topic describes metadata in <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) and provides instructions for adding, updating, removing, and viewing metadata.
 
-<div class="note">
-  <strong>Note:</strong> This topic includes references to cf CLI v7 beta commands. When using these commands, consider:
-    <ul>
-      <li> cf CLI v7 beta and CAPI v3 are both in active development and subject to change. </li>
-      <li> cf CLI v7 beta is developed and tested against the latest CAPI release candidate. </li>
-      <li> cf CLI v7 beta does not yet use CAPI v3 for all commands. Some commands still use CAPI v2 during beta. </li>
-    </ul>
-  For more information, see <a href="../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>.
-</div>
-
-
 ## <a id="about"></a> About Metadata
 
 <%= vars.app_runtime_abbr %> allows you to add metadata to resources such as spaces and apps. You can use metadata to provide additional information about the resources in your <%= vars.app_runtime_abbr %> deployment. This can help with operating, monitoring, and auditing.
@@ -169,7 +158,7 @@ Consider an example in which you have two scanner tools: one for security and on
 
 The following sections describe how to add, update, view, and list metadata using the cf CLI.
 
-<p class="note"><strong>Note:</strong> To see which resources are supported for this feature, run <code>cf7 labels -h</code>. At the time of public beta, cf CLI v7 beta supports adding labels to apps, orgs, spaces, buildpacks, stacks, and domains.</p>
+<p class="note"><strong>Note:</strong> To see which resources are supported for this feature, run <code>cf7 labels -h</code>. cf CLI v7 currently supports adding labels to apps, orgs, spaces, buildpacks, stacks, routes, domains, and various service resources.</p>
 
 ### <a id="add-cli"></a> Add Metadata to a Resource
 


### PR DESCRIPTION
Hi Docs Team. We are preparing to GA cf CLI version 7. We are trying to remove references to any beta tags left behind. This is one of 3 PRs. The others should be in docs-cf-cli, docs-dev-guide.