### PR TITLE
remove loggregator agent port 3457

### DIFF
--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -403,7 +403,7 @@ To configure firewall rules for isolation segment traffic:
       <tr>
         <td><code>is1-to-<%= vars.app_runtime_abbr_lc %></code></td>
         <td>Isolation segment</td>
-        <td><code>tcp:3000, 3001, 3457, 4003, 4103, 4222, 4443, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
+        <td><code>tcp:3000, 3001, 4003, 4103, 4222, 4443, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
         <td><%= vars.app_runtime_abbr %> Diego Cells</td>
         <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %> Diego Cells. Loggregator Agent to reach Traffic Controller. Gorouters to reach NATS, UAA, and Routing API.</td>
       </tr>
@@ -467,12 +467,6 @@ To understand which protocols and ports map to which processes and manifest prop
   <td><code>3001</code></td>
   <td>Routing API</td>
   <td><code>routing_api.mtls_port</code></td>
-</tr>
-<tr>
-  <td><code>tcp</code></td>
-  <td><code>3457</code></td>
-  <td>Doppler</td>
-  <td><code>metron_endpoint.dropsonde_port</code></td>
 </tr>
 <tr>
   <td><code>tcp</code></td>


### PR DESCRIPTION
Co-authored-by: Gary Liu <galiu@pivotal.io>
Co-authored-by: Mark Stokan <mstokan@pivotal.io>

[#172795055] Update Docs for IST firewalls with only needed ports