### PR TITLE
update statement on cf cli v7 TCP routing support

### DIFF
--- a/enabling-tcp-routing.html.md.erb
+++ b/enabling-tcp-routing.html.md.erb
@@ -5,7 +5,7 @@ owner: Routing
 
 This topic describes enabling TCP Routing for your <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) deployment. This feature enables developers to run apps that serve requests on non-HTTP TCP protocols. You can use TCP routing to comply with regulatory requirements that require your org to terminate the TLS as close to your apps as possible so that packets are not decrypted before reaching the app level.
 
-<p class="note"><strong>Note:</strong> cf CLI v7 does not support TCP routing. Creating TCP routes only applies to cf CLI v6.</p>
+<p class="note"><strong>Note:</strong> cf CLI v7's support of TCP routing depends on `CAPI API v3.85.0+`. CLI's targetting foundations with older versions of the API should use cf CLI v6 for creating TCP routes.</p>
 
 
 ## <a id="ports"></a> Route Ports


### PR DESCRIPTION
the v7 CLI actually DOES support TCP routing.
BUT it only supports TCP routing against TAS v2.10+ (so this statement should be updated as per the change in this PR for all docs <TAS2.10, and for the current OSS docs it's fine as well) --- and this warning should NOT be displayed at all for TAS v2.10+