### PR TITLE
remove cf cli 2.26.0 warnings

### DIFF
--- a/isolation-segments.html.md.erb
+++ b/isolation-segments.html.md.erb
@@ -48,8 +48,6 @@ After an admin creates a new isolation segment, the admin can then create and ma
 
 ## <a name='requirements'></a> Requirements
 
-You must have Cloud Foundry Command Line Interface (cf CLI) v.6.26.0 or later installed to manage isolation segments. To download the latest version of the cf CLI, see the [Releases](https://github.com/cloudfoundry/cli/releases) section of the Cloud Foundry CLI repository on GitHub. For more information about installing the cf CLI, see [Installing the cf CLI](../cf-cli/install-go-cli.html).
-
 Target the API endpoint of your deployment with `cf api` and log in with `cf login` before performing the procedures in this topic. <%= vars.api_endpoint_book %>
 
 


### PR DESCRIPTION
- cf cli 2.26.0 came out in 2017. 
- can prob stop warning about it in 2.10+

I think I am doing this on the 2.10, branch. If not pls lmk.

Thanks!
🐱 