### PR TITLE
Consolidate TCP Routing pages

### DIFF
--- a/enabling-tcp-routing.html.md.erb
+++ b/enabling-tcp-routing.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Enabling TCP Routing
+title: Enabling and Configuring TCP Routing
 owner: CF for VMs Networking
 ---
 
-This topic describes enabling TCP Routing for your <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) deployment. This feature enables developers to run apps that serve requests on non-HTTP TCP protocols. You can use TCP routing to comply with regulatory requirements that require your org to terminate the TLS as close to your apps as possible so that packets are not decrypted before reaching the app level.
+This topic describes what TCP Routing is and how to enable the feature in your <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) deployment. TCP Routing enables developers to run apps that serve requests on non-HTTP TCP protocols. TCP routing can be used to comply with regulatory requirements that require TLS to be terminated as close to apps as possible so that packets are not decrypted before reaching the app level.
 
-## <a id="ports"></a> Route Ports
+## <a id="architecture"></a> Architecture
 
 The diagram below shows the layers of network address translation that occur in <%= vars.app_runtime_abbr %> in support of TCP Routing. The descriptions step through an example work flow that covers route ports, back end ports, and app ports.
 
@@ -17,6 +17,8 @@ The diagram below shows the layers of network address translation that occur in 
 
 - The load balancer listens on the port and forwards requests for the domain to the TCP routers. The load balancer must listen on a range of ports to support multiple TCP route creation. Additionally, <%= vars.app_runtime_abbr %> must be configured with this range, so that the platform knows what ports can be reserved when developers create TCP routes.
 
+- The TCP routers are organized into router groups. A router group is a cluster of identically configured routers. Router groups are a mechanism to support reservation of the same port for multiple TCP routes, thus increasing the capacity for TCP routes. However, only one router group is currently supported.
+
 - The TCP router can be dynamically configured to listen on the port when the route is mapped to an app. The domain the request was originally sent to is no longer relevant to the routing of the request to the app. The TCP router keeps a dynamically updated record of the back ends for each route port. The back ends represent instances of an app mapped to the route. The TCP router chooses a back end using a round-robin load balancing algorithm for each new TCP connection from a client. As the TCP router is protocol-agnostic, it does not recognize individual requests, only TCP connections. All client requests transit the same connection to the selected back end until the client or back end closes the connection. Each subsequent connection  triggers the selection of a back end.
 
 - Because containers each have their own private network, the TCP router does not have direct access to app containers. When a container is created for an app instance, a port on the Diego Cell VM is randomly chosen and iptables are configured to forward requests for this port to the internal interface on the container. The TCP router then receives a mapping of the route port to the Diego Cell IP and port.
@@ -24,7 +26,8 @@ The diagram below shows the layers of network address translation that occur in 
 - By default, the Diego Cell only routes requests to port `8080`, the app port, on the container internal interface. The app port is the port on which apps must listen. Developers can use the Cloud Controller API to update the ports an app can receive requests on. For more information, see [Configuring Apps to Listen on Custom Ports (Beta)](../devguide/custom-ports.html).
 
 
-## <a id="pre-deploy"></a> Pre-Deployment Steps
+## <a id="enable-tcp-routing"></a> Enable TCP Routing
+### <a id="pre-deploy"></a> Pre-Deployment Steps
 
 <%= vars.mutual_tls_tcp %>
 
@@ -42,13 +45,43 @@ Before enabling TCP routing, you must set up networking requirements. To set up 
 1. <%= partial vars.tcp_port %>
 
 
-## <a id="post-deploy"></a> Post-Deployment Steps
+<% if vars.platform_code == "PCF" %>
+### <a id="config-tcp"></a> Configure TCP Routing
+
+TCP routing is disabled by default.
+
+To enable TCP routing:
+
+1. Navigate to the <%= vars.ops_manager_full %> Installation Dashboard.
+
+1. Click the <%= vars.app_runtime_abbr %> tile.
+
+1. Select **Networking**.
+
+1. Under **TCP routing**, select **Enable**.
+
+1. For **TCP router IPs**, enter the IP addresses to assign to the TCP routers as multiple values as a comma-separated list or as a range. For example, `10.254.0.1, 10.254.0.2` or `10.254.0.1-10.254.0.2`. These addresses must be within your subnet CIDR block. The addresses are the same IP addresses with which you configured your load balancer in the [Pre-Deployment Steps](#pre-deploy) section of _Enable TCP Routing_, unless you configured DNS to resolve the TCP domain name directly to an IP for the TCP router.
+
+1. For **TCP routing ports**, enter one or more ports to which the load balancer forwards requests. To support multiple TCP routes, <%= vars.company_name %> recommends allocating multiple ports. Do one of the following:
+    * To allocate a single port or range of ports, enter a single port or a range of ports.
+      <p class="note"><strong>Note:</strong> If you configured AWS for <%= vars.app_runtime_abbr %> manually, enter <code>1024-1123</code> which corresponds to the rules you created for <code><%= vars.platform_name_lc %>-tcp-elb</code>.</p>
+    * To allocate a list of ports:
+      1. Enter a single port in the **TCP routing ports** field.
+      1. After deploying <%= vars.app_runtime_abbr %>, follow the procedure in [Router Groups: Modify TCP port reservations](#modify-ports) to add TCP routing ports using the cf CLI.
+
+1. (Optional) For **TCP request timeout**, modify the default value of `300` seconds. This field determines when the TCP router closes idle connections from clients to apps that use TCP routes. You may want to increase this value to enable developers to push apps that require long-running idle connections with clients.
+
+1. For **AWS**, **Azure**, or **GCP** <%= vars.platform_name %> deployments, add the name of your load balancer to the **TCP Router** field in the **Resource Config** pane of the <%= vars.app_runtime_abbr %> tile. For more information, see [Configuring Load Balancing for <%= vars.app_runtime_abbr %>](configure-lb.html).
+
+<% end %>
+
+### <a id="post-deploy"></a> Post-Deployment Steps
 
 In the following procedures, you use the Cloud Foundry Command Line Interface (cf CLI) to add the TCP shared domain and configure org quotas to grant developers the ability to create TCP routes. This requires an admin user account.
 
 For more information about the cf CLI, see [Using the Cloud Foundry Command Line Interface (cf CLI)](../cf-cli/index.html).
 
-### <a id="configure-domain"></a> Configure <%= vars.app_runtime_abbr %> with Your TCP Domain
+#### <a id="configure-domain"></a> Configure <%= vars.app_runtime_abbr %> with Your TCP Domain
 
 After deployment, you must configure <%= vars.app_runtime_abbr %> with the domain that you configured in the pre-deployment step above so developers can create TCP routes from it.
 
@@ -61,7 +94,7 @@ After deployment, you must configure <%= vars.app_runtime_abbr %> with the domai
 
 1. Run `cf domains`. Verify that next to your TCP domain, `TCP` appears under `type`.
 
-### <a id="configure-quota"></a> Configure a Quota for TCP Routes
+#### <a id="configure-quota"></a> Configure a Quota for TCP Routes
 
 Since TCP route ports are a limited resource in some environments, quotas are configured to allow creation of zero TCP routes by default. After you deploy <%= vars.app_runtime_abbr %>, you can increase the maximum number of TCP routes for all orgs or for particular orgs and spaces. Because you reserve a route port for each TCP route, the quota for this resource is managed with the cf CLI command option `--reserved-route-ports`. For more information, see [Creating and Modifying Quota Plans](../adminguide/quota-plans.html).
 
@@ -83,17 +116,29 @@ You can also create a quota that governs the number of route ports that can be c
 cf create-space-quota QUOTA --reserved-route-ports X
 ```
 
+<% if vars.platform_code == "PCF" %>
+## <a id="disable-tcp"></a> Disable TCP Routing
 
-## <a id="create-tcp-route"></a> Create a TCP Route
+To disable TCP routing:
+
+1. Navigate to the <%= vars.ops_manager %> Installation Dashboard.
+
+1. Click the <%= vars.app_runtime_abbr %> tile.
+
+1. Select **Networking**.
+
+1. Under **TCP routing**, select **Disable**.
+
+1. Manually remove the TCP routing domain.
+
+<% end %>
+
+## <a id="administering-tcp-routing"></a> Further TCP Routing Administration
+### <a id="create-tcp-route"></a> Create a TCP Route
 
 For information about creating a TCP Route, see the [Create a TCP Route with a Port](../devguide/deploy-apps/routes-domains.html#create-route-with-port) section of the _Configuring Routes and Domains_ topic.
 
-
-## <a id="router-groups"></a> Router Groups
-
-[Post-Deployment Steps](#configure-domain) describes that in order to create a domain from which to create TCP routes, it must be associated with the TCP router group. A router group is a cluster of identically configured routers. Router groups are a mechanism to support reservation of the same port for multiple TCP routes, thus increasing the capacity for TCP routes. However, only one router group is currently supported. [Pre-Deployment Steps](#pre-deploy) describes how an admin user can configure the port range available for TCP routes in preparation for deployment.
-
-### <a id="modify-ports"></a> Modify Your TCP ports
+### <a id="modify-ports"></a> Router Groups: Modify TCP port reservations
 
 After deployment, you can modify the range of ports available for TCP routes using `cf curl` commands, as demonstrated with the commands below. These commands require an admin user with the `routing.router_groups.read` and `routing.router_groups.write` scopes.
 
@@ -113,5 +158,7 @@ After deployment, you can modify the range of ports available for TCP routes usi
 1. Modify the `reservable_ports`:
 
     <pre class="terminal">
-    $ cf curl /routing/v1/router_groups/f7392031-a488-4890-8835-c4a038a3bded -X PUT -d '{"reservable_ports":"1024-1199"}'
+    $ cf curl \
+    -X PUT -d '{"reservable_ports":"1024-1199"}' \
+    /routing/v1/router_groups/f7392031-a488-4890-8835-c4a038a3bded
     </pre>


### PR DESCRIPTION
## The Change
Merges content of:
- docs-cf-admin/enabling-tcp-routing
- docs-operating-pas/tcp-routing-ert-config

into → docs-cf-admin/enabling-tcp-routing

Tracker: [#174580463](https://www.pivotaltracker.com/story/show/174580463)

## PR Acceptance Notes
Please backport this change to TAS `2.7`.

Related PRs:
- cloudfoundry/docs-cf-admin#192
- pivotal-cf/docs-operating-pas#39
- pivotal-cf/docs-partials#28