### PR TITLE
Remove redundant gorouter arch doc

### DIFF
--- a/docker.html.md.erb
+++ b/docker.html.md.erb
@@ -84,7 +84,7 @@ To determine which processes to run, the Cloud Controller fetches and stores the
 
 * Instruct Diego and the Gorouter to route traffic to the lowest-numbered port exposed in the Docker image, or port 8080 if the Dockerfile does not explicitly expose a listen port.
 
-For more information about Cloud Controller, see [Cloud Controller](../concepts/architecture/cloud-controller.html). For more information about the Gorouter, see [Gorouter](../concepts/architecture/router.html). For more information about exposed ports in Docker images, see the [Expose](https://docs.docker.com/engine/reference/builder/#expose) section of the _Dockerfile reference_ topic in the Docker documentation.
+For more information about Cloud Controller, see [Cloud Controller](../concepts/architecture/cloud-controller.html). For more information about Gorouter and the routing tier, see [<%= vars.app_runtime_abbr %> Routing Architecture](../concepts/cf-routing-architecture.html). For more information about exposed ports in Docker images, see the [Expose](https://docs.docker.com/engine/reference/builder/#expose) section of the _Dockerfile reference_ topic in the Docker documentation.
 
 <p class='note'><strong>Note:</strong> When launching an app on Diego, the Cloud Controller honors any user-specified overrides such as a custom start command or custom environment variables.</p>
 

--- a/troubleshooting-router-error-responses.html.md.erb
+++ b/troubleshooting-router-error-responses.html.md.erb
@@ -37,9 +37,115 @@ Some general debugging steps for any issue resulting in 502 errors are as follow
    - Was there a recent platform change or upgrade that caused an increase in 502 errors?
    - Are there any suspicious [metrics](<%= vars.gorouter_metrics_link %>) spiking? How is the CPU and memory utilization?
 
+## <a id="log-formatting"></a>Log Formatting
+
+### <a id="levels"></a> Levels
+
+The following table describes the log levels supported by Gorouter.
+<% if vars.platform_code == 'CF' %>
+The log level is specified in the configuration YAML file for Gorouter.
+<% else %>
+The log level is set to `debug` and is not configurable.
+<% end %>
+
+<table>
+  <tr>
+    <th>Message</th>
+    <th>Description</th>
+    <th>Examples</th>
+  </tr>
+  <tr>
+    <td><code>fatal</code></td>
+    <td>Gorouter is unable to handle any requests due to a fatal error.</td>
+    <td>Gorouter cannot bind to its TCP port, a <%= vars.app_runtime_abbr %> component has
+  published invalid data to Gorouter.</td>
+  </tr>
+  <tr>
+    <td><code>error</code></td>
+    <td>An unexpected error has occurred.</td>
+    <td>Gorouter failed to fetch token from UAA service.</td>
+  </tr>
+  <tr>
+    <td><code>info</code></td>
+    <td>An expected event has occurred.</td>
+    <td>Gorouter started or exited, Gorouter has begun to prune
+  routes for stale droplets.</td>
+  </tr>
+  <tr>
+    <td><code>debug</code></td>
+    <td>A lower-level event has occurred.</td>
+    <td>Route registration, route unregistration.</td>
+  </tr>
+</table>
+
+### <a id="message-contents"></a> Message Contents
+
+This section section provides a sample Gorouter log entry and explanation of the contents.
+
+`[2017-02-01 22:54:08+0000] {"log_level":0,"timestamp":1485989648.0895808,"message":"endpoint-registered","source":"vcap.Gorouter.registry","data":{"uri":"0-*.login.bosh-lite.com","backend":"10.123.0.134:8080","modification_tag":{"guid":"","index":0}}}
+`
+
+<table>
+  <tr>
+    <th>Property</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>log_level</code></td>
+    <td>Logging level of the message</td>
+  </tr>
+  <tr>
+    <td><code>timestamp</code></td>
+    <td>Epoch time of the log</td>
+  </tr>
+  <tr>
+    <td><code>message</code></td>
+    <td>Content of the log entry</td>
+  </tr>
+  <tr>
+    <td><code>source</code></td>
+    <td>Gorouter function that initiated the log entry</td>
+  </tr>
+  <tr>
+    <td><code>data</code></td>
+    <td>Additional information that varies based on the message</td>
+  </tr>
+</table>
+
+### <a id="access-logs"></a> Access Logs
+
+This section provides details about Gorouter access logs.
+
+Gorouter generates an access log in the following format when it receives a request:
+
+`<Request Host> - [<Start Date>] "<Request Method> <Request URL> <Request Protocol>" <Status Code> <Bytes Received> <Bytes Sent> "<Referrer>" "<User-Agent>" <Remote Address> <Backend Address> x_forwarded_for:"<X-Forwarded-For>" x_forwarded_proto:"<X-Forwarded-Proto>" vcap_request_id:<X-Vcap-Request-ID> response_time:<Response Time> gorouter_time:<Gorouter Time> app_id:<Application ID> app_index:<Application Index> x_cf_routererror:<X-Cf-RouterError> <Extra Headers>`
+
+Gorouter access logs are also redirected to syslog.
+
+See the list below for more information about the Gorouter access log fields:
+
+* The following are optional fields: <code>Status Code</code>, <code>Response Time</code>, <code>Application ID</code>, <code>Application Index</code>, <code>X-Cf-RouterError</code>, and <code>Extra Headers</code>.
+
+* If the access log lacks a <code>Status Code</code>,  <code>Response Time</code>, <code>Application ID</code>, <code>Application Index</code>, or <code>X-Cf-RouterError</code>, the corresponding field shows `-`.
+
+* `Response Time` is the total time it takes for the request to go through the Gorouter to the app
+   and for the response to travel back through the Gorouter.
+   This includes the time that the request spends traversing the network to the app and back again to the Gorouter.
+   It also includes the time the app spends forming a response.
+
+* `Gorouter Time` is the total time it takes for the request to go through the Gorouter
+   initially plus the time it takes for the response to travel back through the Gorouter.
+   This does not include the time the request spends traversing the network to the app.
+   This also does not include the time the app spends forming a response.
+
+* `X-Cf-RouterError` is populated if the Gorouter encounters an error. The returned values can
+   help distinguish whether a non-2xx response code is due to an error in the Gorouter
+   or the back end. For more information on the possible errors, see
+   the [Diagnose App Errors](#app-errors) section.
+
 ## <a id="gorouter"></a>Diagnose Gorouter Errors
 
-This section describes how to diagnose Gorouter errors.
+This section describes the basic structure of Gorouter logs and how to diagnose Gorouter errors.
 
 ### <a id="cannot-connect"></a>Gorouter Cannot Connect to the App Container
 


### PR DESCRIPTION
## The Change
tl;dr: The information contained on that page was represented elsewhere and the page no longer needs to exist.

- the home for the majority of this content is in:
  - `docs-cloudfoundry-concepts/cf-routing-architecture.html`
  - `docs-cf-admin/troubleshooting-router-error-responses.html`

- Removes the following file and all links to file: `docs-cloudfoundry-concepts/architecture/router.html(.md.erb)`
- change link destinations to a more appropriate page
  - usually `docs-cloudfoundry-concepts/cf-routing-architecture.html`
- reorganize the flow of `docs-cloudfoundry-concepts/cf-routing-architecture.html`

PivotalTracker: [#174579096](https://www.pivotaltracker.com/story/show/174579096)

## Backports
Please backport these changes to TAS 2.7.

## Related PRs
- cloudfoundry/docs-cloudfoundry-concepts/pull/148
- cloudfoundry/docs-cf-admin/pull/193
- cloudfoundry/docs-book-cloudfoundry/pull/105
- pivotal-cf/docs-book-windows/pull/4
- pivotal-cf/docs-operating-pas/pull/40
- pivotal-cf/docs-partials/pull/29
- pivotal-cf/docs-pcf-windows/pull/73
- cloudfoundry/docs-routing/pull/3
- pivotal-cf/docs-tiledev/pull/106