### PR TITLE
Remove "Skip SSL Certificate Verification"

### DIFF
--- a/troubleshooting-router-error-responses.html.md.erb
+++ b/troubleshooting-router-error-responses.html.md.erb
@@ -91,8 +91,6 @@ If TLS from Gorouter to apps and other backends is enabled, then when Gorouter d
 TLS from Gorouter to apps and other backends is enabled by default in cf-deployment v7.0.0.
 <% else %>
 TLS from Gorouter to apps and other backends is always enabled in <%= vars.app_runtime_abbr %> v2.4.0 and later.
-
-<p class='note'><strong>Note:</strong> This feature does not work if the <strong>Disable SSL certificate verification for this environment</strong> checkbox is selected in the <strong>Networking</strong> pane of the <%= vars.app_runtime_abbr %> tile.</p>
 <% end %>
 
 ### <a id="stale-routes"></a> Causes of Stale Routes


### PR DESCRIPTION
## The Change
- Makes `ha_proxy.skip_cert_verify` (Skip SSL Certificate Verification)
unconfigurable and defaulted to `false`
- Removes the form from the tile UI
- Adds migration to prevent upgrading when this feature is configured
`true`
- Removes all documentation referencing to this setting
- Updates Ops Man documentation for case when users want to provide
their own self-signed certificate

[#174811172](https://www.pivotaltracker.com/story/show/174811172)

Co-authored-by: Josh Russett <jrussett@vmware.com>
Co-authored-by: Ryan Hall <hallr@vmware.com>

## Backports
None

## Related PRs
#### Tiles
- pivotal-cf/p-runtime#1826
- pivotal-cf/p-isolation-segment#503
#### Docs
- pivotal-cf/docs-partials#31
- cloudfoundry/docs-cf-admin#194
- pivotal-cf/docs-operating-pas#41
- pivotal-cf/docs-pivotalcf-console#16