### PR TITLE
Update Gorouter Back End Keep-Alive Connections Docs with Caveat about Potential Race Condition

### DIFF
--- a/routing-keepalive.html.md.erb
+++ b/routing-keepalive.html.md.erb
@@ -20,3 +20,7 @@ Each Gorouter process is limited to 100,000 file descriptors. Each inbound reque
 In order to determine how many idle connections are needed, consider that the peak connections could be calculated by multiplying throughput by response time. For example, if a single Gorouter receives 1000 requests per second, and response time is 1 second, at any given time there are likely to be 1000 connections open to back ends. Accommodating for growth of 2x, an operator might configure a maximum of 2000 idle connections per Gorouter.
 
 The Gorouter has been hardcoded with a limit of 100 idle connections per back end. The configurable property `max_idle_connections` governs idle connections across all back ends.
+
+## <a id="application-idle-timeout"></a> Considerations for Applications when Keep-Alive Connections are Enabled
+
+When keep-alive connections with back ends is enabled it is important that the Gorouter and not the application is reponsible for closing connections. If the application instance closes a connection at the _exact_ same time that the Gorouter sends a new request using that connection, the request will fail. With keep-alive enabled, the Gorouter closes idle connections after 90 seconds, therefore application servers should be configured with a keep-alive idle timeout to be greater than 90 seconds, ensuring that the Gorouter always closes connections first.

--- a/troubleshooting-router-error-responses.html.md.erb
+++ b/troubleshooting-router-error-responses.html.md.erb
@@ -353,6 +353,8 @@ The app might be overloaded, unresponsive, or unable to connect to the database.
 
 If all apps are experiencing 502 errors, then it could either be a platform issue, such as a misconfiguration, or an app issue, such as all apps being unable to connect to an upstream database.
 
+If the gorouter has [backend keep-alive connections](../adminguide/routing-keepalive.html) enabled, 502 errors may occasionally occur due to a [race condition](../adminguide/routing-keepalive.html#application-idle-timeout) when the application instance keep-alive idle timeout is less than 90 seconds.
+
 <p class='note'><strong>Note:</strong> Gorouter does not retry any error response returned by the app.</p>
 
 ### Gorouter specific Response Headers


### PR DESCRIPTION
Hi folks, 

When Gorouter back end keep-alive connections is enabled, users are exposed to a potential race condition if their application keep-alive idle timeouts are not correctly configured. This PR updates the docs to inform users about this.

The Gorouter backend idle timeout value of 90 seconds comes from [this](https://github.com/cloudfoundry/gorouter/blob/main/proxy/proxy.go#L113) hardcoded value.

Supporting information about why it's important for _senders_ to close connections before _receivers_ do:

https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html
> To ensure that the load balancer is responsible for closing the connections to your instance, **make sure that the value you set for the HTTP keep-alive time is greater than the idle timeout setting configured for your load balancer**.

https://docs.pivotal.io/application-service/2-8/operating/frontend-idle-timeout.html
> In general, set the value higher than your load balancer’s back end idle timeout to **avoid the race condition where the load balancer sends a request before it discovers that the Gorouter or HAProxy has closed the connection**.

https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340
> This causes the load balancer to be the side that closes idle connections, rather than nginx, which fixes the race condition! 

https://tanzu.vmware.com/content/pivotal-engineering-journal/understanding-keep-alive-timeouts-in-the-cloud-foundry-networking-stack-2
> Let’s look from the “outside” (the client) to the “inside” (the server in the deployment). As you travel further in, the **keep-alive timeouts should be configured to be longer**. That is, the outermost layer (in this case, the client) should have the shortest backend keep-alive timeout, and as you go in, the keep-alive timeouts should get progressively longer in relation to the corresponding backend or frontend idle timeout

 
> Consider Golang’s HTTP client, which we believe to be somewhat robust to this type of client-side problem. The low level http transport package used by the default client implements a background loop that checks if a connection in its idle pool has been closed by the server before reusing it to make a request. **This leaves a small window for a race condition where the server could close the connection between the check and the new request**; in the event that the client loses this race, it retries this request on a new connection. 

kind regards,

Pete