### PR TITLE
Emphasize more on the backend idle-timeout for app containers

### DIFF
--- a/routing-keepalive.html.md.erb
+++ b/routing-keepalive.html.md.erb
@@ -24,7 +24,10 @@ The Gorouter has been hardcoded with a limit of 100 idle connections per back en
 ## <a id="app-idle-timeout"></a> Considerations for Apps when Keep-Alive Connections are Enabled
 
 When keep-alive connections with back ends is enabled, the Gorouter must be reponsible for closing connections.
-If an app instance closes a connection at the exact same time that the Gorouter sends a new request using that connection, the request fails.
+If an app instance closes a connection at the exact same time that the Gorouter sends a new request using that connection, the request fails, and the
+client receives an HTTP 502 error.
 
-With keep-alive enabled, the Gorouter closes idle connections after 90 seconds.
-Configure app servers with a keep-alive idle timeout greater than 90 seconds to make sure that the Gorouter always closes connections first.
+<p class="note"><strong>Note:</strong> With keep-alive enabled, the Gorouter closes idle connections after 90 seconds.
+It's very important to configure app servers with a keep-alive idle timeout greater than 90 seconds to make sure that the Gorouter always closes connections first. 
+The app server keep-alive idle timeout is language specific, and the default value often needs to be adjusted to meet this requirement.
+</p>


### PR DESCRIPTION
Emphasize the importance of setting app container keep-alive idle timeout to be greater than 90 seconds. We have been spending quite some time, with multiple support cases, and this turned out to be the reason/solution. Hope the emphasis will save others time.