### PR TITLE
Distribution may not support customising the router status port

### DIFF
--- a/configure-lb-healthcheck.html.md.erb
+++ b/configure-lb-healthcheck.html.md.erb
@@ -17,9 +17,9 @@ Configure your load balancer to use the following HTTP health check endpoints. A
   * Gorouter (HTTP router): `http://GOROUTER_IP:8080/health`
   * TCP router: `http://TCP_ROUTER_IP:80/health`
 
+<% if vars.platform_code == 'CF' %>
 The configuration above assumes the default health check ports for the <%= vars.app_runtime_abbr %> routers. To modify these ports, see the sections below. 
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'go_tcp_routers_health_check_oss' %>
 <% end %>
 


### PR DESCRIPTION
If the health check ports are not able to be configured then the existing documentation reads strangely.

Move the reference to modifying ports to within the same conditional as the text it is referring to.