### PR TITLE
Fix HostnameMismatch troubleshooting formatting

### DIFF
--- a/troubleshooting-router-error-responses.html.md.erb
+++ b/troubleshooting-router-error-responses.html.md.erb
@@ -299,7 +299,7 @@ If the request is one that can be retried, Gorouter makes up to three attempts.
     <td>503</td>
     <td>Yes</td>
     <td>Platform</td>
-    <td>Logs with error <code>x509: certificate is valid for <x> not <y></code><br/> or <code>backend_invalid_id</code> metric increments</td>
+    <td>Logs with error <code>x509: certificate is valid for < x >, not < y > </code><br/> or <code>backend_invalid_id</code> metric increments</td>
   </tr>
   <tr>
     <td>UntrustedCert</td>


### PR DESCRIPTION
`<x>` and `<y>` are not rendered within a html code element, 
therefore this commit introduces spaces.
Fixes formatting error introduced with 5dc50dd0521cdca91d287a44c59f691011165c93

Furthermore, adds a missing comma.

Signed-off-by: Jürgen Walter <juergen.walter@sap.com>