### PR TITLE
Document log cache syslog server port

### DIFF
--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -408,9 +408,9 @@ To configure firewall rules for isolation segment traffic:
       <tr>
         <td><code>is1-to-<%= vars.app_runtime_abbr_lc %></code></td>
         <td>Isolation segment</td>
-        <td><code>tcp:3000, 3001, 4003, 4103, 4222, 4443, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
+        <td><code>tcp:3000, 3001, 4003, 4103, 4222, 4443, 6067, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
         <td><%= vars.app_runtime_abbr %> Diego Cells</td>
-        <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %>. Loggregator Agent to reach Doppler. Gorouters to reach NATS, UAA, and Routing API.</td>
+        <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %>. Loggregator Agent to reach Doppler. Syslog Agent to reach Log Cache Syslog Server. Gorouters to reach NATS, UAA, and Routing API.</td>
       </tr>
     </table>
 
@@ -496,6 +496,12 @@ To understand which protocols and ports map to which processes and manifest prop
   <td><code>4443</code></td>
   <td>CAPI Blobstore Port - HTTPS</td>
   <td><code>capi.blobstore.tls.port</code></td>
+</tr>
+<tr>
+  <td><code>tcp</code></td>
+  <td><code>6067</code></td>
+  <td>Log Cache Syslog Server</td>
+  <td><code>log-cache.log-cache-syslog-server.syslog_port</code></td>
 </tr>
 <tr>
   <td><code>tcp</code></td>

--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -408,9 +408,9 @@ To configure firewall rules for isolation segment traffic:
       <tr>
         <td><code>is1-to-<%= vars.app_runtime_abbr_lc %></code></td>
         <td>Isolation segment</td>
-        <td><code>tcp:3000, 3001, 4003, 4103, 4222, 4443, 6067, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
+        <td><code>tcp:3000, 3001, 4003, 4103, 4222, 4224, 4443, 6067, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
         <td><%= vars.app_runtime_abbr %> Diego Cells</td>
-        <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %>. Loggregator Agent to reach Doppler. Syslog Agent to reach Log Cache Syslog Server. Gorouters to reach NATS, UAA, and Routing API.</td>
+        <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %>. Loggregator Agent to reach Doppler. Syslog Agent to reach Log Cache Syslog Server. Gorouters to reach NATS, UAA, and Routing API. Metrics Discovery Registrar to reach NATS.</td>
       </tr>
     </table>
 
@@ -490,6 +490,12 @@ To understand which protocols and ports map to which processes and manifest prop
   <td><code>4222</code></td>
   <td>NATS</td>
   <td><code>nats.nats.port</code></td>
+</tr>
+<tr>
+  <td><code>tcp</code></td>
+  <td><code>4224</code></td>
+  <td>NATS</td>
+  <td><code>nats-tls.nats.port</code></td>
 </tr>
 <tr>
   <td><code>tcp</code></td>

--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -518,7 +518,7 @@ To understand which protocols and ports map to which processes and manifest prop
 <tr>
   <td><code>tcp</code></td>
   <td><code>8084</code></td>
-  <td>Diego file server - HTTP (Small Footprint TAS)</td>
+  <td>Diego file server - HTTP</td>
   <td><code>diego.file_server.listen_addr</code></td>
 </tr>
 <tr>

--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -410,7 +410,7 @@ To configure firewall rules for isolation segment traffic:
         <td>Isolation segment</td>
         <td><code>tcp:3000, 3001, 4003, 4103, 4222, 4443, 8080, 8082, 8083, 8443, 8447, 8844, 8853, 8889, 8891, 9000, 9022, 9023, 9090, 9091</code></td>
         <td><%= vars.app_runtime_abbr %> Diego Cells</td>
-        <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %> Diego Cells. Loggregator Agent to reach Traffic Controller. Gorouters to reach NATS, UAA, and Routing API.</td>
+        <td>Diego Cells in isolation segment to reach Diego BBS, Diego Auctioneer, and CredHub in <%= vars.app_runtime_abbr %>. Loggregator Agent to reach Doppler. Gorouters to reach NATS, UAA, and Routing API.</td>
       </tr>
     </table>
 


### PR DESCRIPTION
Recently [the default for Log Cache ingress was changed in cf-deployment](https://github.com/cloudfoundry/cf-deployment/releases/tag/v18.0.0). Log Cache had been using the Reverse Log Proxy by default but now defaults to using syslog ingress.

This means that Diego Cells need to be able to initiate connections to the Log Cache Syslog Server. This PR updates the *Routing for Isolation Segments* docs to include port 6067 which is the [default port that Log Cache Syslog Server listens on](https://github.com/cloudfoundry/log-cache-release/blob/v2.11.6/jobs/log-cache-syslog-server/spec#L31-L33).

I've also added port 4224 which may need to be open for secure NATS communication, and removed a vendor-specific reference.

Please let me know if you would like us to issue separate PRs for earlier docs versions.