### PR TITLE
Update troubleshooting-router-error-responses.html.md.erb

### DIFF
--- a/troubleshooting-router-error-responses.html.md.erb
+++ b/troubleshooting-router-error-responses.html.md.erb
@@ -372,6 +372,8 @@ If all apps are experiencing 502 errors, then it could either be a platform issu
 
 If the Gorouter has back end keep-alive connections enabled, 502 errors can occur due to a race condition when the app instance keep-alive idle timeout is less than 90 seconds.
 For more information, see [Gorouter Back End Keep-Alive Connections](../adminguide/routing-keepalive.html).
+  
+For any other errors, if they appear in Gorouter access logs analyze application logs for futher investigation.
 
 <p class='note'><strong>Note:</strong> Gorouter does not retry any error response returned by the app.</p>
 


### PR DESCRIPTION
We received a request why other errors are not mentioned in this document. These are the errors returned by application and in that case they will appear in gorouter access logs. Next step would be analyze application logs. Usually, it is done first application logs and then gorouter logs, but sometimes operator might be just looking at access logs.