### PR TITLE
Include note to consider syslog drains

### DIFF
--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -429,6 +429,9 @@ To configure firewall rules for isolation segment traffic:
       </tr>
     </table>
 
+Additional firewall rules may be necessary to allow logs to egress to application syslog drains. Connections for syslog drains are initiated both from Diego Cells and
+Routers.
+
 For more information about ports used by agents to communicate with BOSH, see the [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment) repository on GitHub.
 
 For more information about networks and firewall rules for GCP, see [Using Subnetworks](https://cloud.google.com/compute/docs/subnetworks) in the GCP documentation.


### PR DESCRIPTION
Operators should ensure connections to syslog endpoints (ports may vary) are allowed from both diego cells and routers within an isolation segment.