### PR TITLE
Update System Metrics Agent port

### DIFF
--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -389,7 +389,7 @@ To configure firewall rules for isolation segment traffic:
       <tr>
         <td><code><%= vars.app_runtime_abbr_lc %>-to-is1</code></td>
         <td><%= vars.app_runtime_abbr %> Diego Cells</td>
-        <td><code>tcp:1801, 8853, 9100</code></td>
+        <td><code>tcp:1801, 8853, 53035</code></td>
         <td>Isolation segment</td>
         <td>Diego BBS in <%= vars.app_runtime_abbr %> Diego Cells to reach Diego Cells in isolation segment</td>
       </tr>
@@ -606,7 +606,7 @@ To understand which protocols and ports map to which processes and manifest prop
 </tr>
 <tr>
   <td><code>tcp</code></td>
-  <td><code>9100</code></td>
+  <td><code>53035</code></td>
   <td>System Metrics Scraper</td>
   <td><code>system-metrics-scraper.loggr-system-metric-scraper.scrape_port</code></td>
 </tr>


### PR DESCRIPTION
While System Metrics Agent port's default was 9100, we saw that it was being overridden to 53035 in every install we know of. The system-metrics-agent default has been updated to 53035 to reflect this as well.