### PR TITLE
fix: set-space-quota to use SPACE argument

### DIFF
--- a/quota-plans.html.md.erb
+++ b/quota-plans.html.md.erb
@@ -398,12 +398,12 @@ To assign a quota plan to a space:
 1. In a terminal window, run:
 
     ```
-    cf set-space-quota ORG QUOTA-NAME
+    cf set-space-quota SPACE QUOTA-NAME
     ```
 
     Where:
     <ul>
-      <li><code>ORG</code> is the name of the space to which you want to assign the quota plan.</li>
+      <li><code>SPACE</code> is the name of the space to which you want to assign the quota plan.</li>
       <li><code>QUOTA-NAME</code> is the name of the quota plan you want to assign to the space.</li>
     </ul>
 


### PR DESCRIPTION
There probably was a copy typo from set-org-quota and the argument was still set as ORG instead of SPACE.