### PR TITLE
 Adjust org quota plan attributes

### DIFF
--- a/quota-plans.html.md.erb
+++ b/quota-plans.html.md.erb
@@ -48,79 +48,76 @@ _Configuring Container-to-Container Networking_.
   <td>silver_quota</td>
 </tr>
 <tr>
-  <td><code>apps.total_memory_in_mb</code></td>
+  <td><code>total_memory_in_mb</code></td>
   <td>Total memory allowed for all the started processes and running tasks in an organization</td>
   <td>An integer</td>
   <td>2048</td>
 </tr>
 <tr>
-  <td><code>apps.total_instances</code></td>
+  <td><code>total_instances</code></td>
   <td>Total instances of all the started processes allowed in an organization.</td>
   <td>An integer</td>
   <td>25</td>
 </tr>
 <tr>
-  <td><code>apps.per_process_memory_in_mb</code></td>
+  <td><code>per_process_memory_in_mb</code></td>
   <td>Maximum memory for a single process or task</td>
   <td>An integer</td>
   <td>2048</td>
 </tr>
 <tr>
-  <td><code>apps.log_rate_limit_in_bytes_per_second</code></td>
+  <td><code>log_rate_limit_in_bytes_per_second</code></td>
   <td>Total log rate limit allowed for all the started processes and running tasks in an organization</td>
   <td>An integer</td>
   <td>1024</td>
 </tr>
 <tr>
-  <td><code>apps.per_app_tasks</code></td>
+  <td><code>per_app_tasks</code></td>
   <td>Maximum number of running tasks in an organization</td>
   <td>An integer</td>
   <td>5</td>
 </tr>
 <tr>
-  <td><code>services.paid_services_allowed</code></td>
+  <td><code>paid_services_allowed</code></td>
   <td>Specifies whether instances of paid service plans can be created.</td>
   <td><code>true</code> or <code>false</code></td>
   <td>true</td>
 </tr>
 <tr>
-  <td><code>services.total_service_instances</code></td>
+  <td><code>total_service_instances</code></td>
   <td>Total number of service instances allowed in an organization.</td>
   <td>An integer</td>
   <td>10</td>
 </tr>
 <tr>
-  <td><code>services.total_service_keys</code></td>
+  <td><code>total_service_keys</code></td>
   <td>Total number of service keys allowed in an organization.</td>
   <td>An integer</td>
   <td>20</td>
 </tr>
 <tr>
-  <td><code>routes.total_routes</code></td>
+  <td><code>total_routes</code></td>
   <td>Total number of routes allowed in an organization.</td>
   <td>An integer</td>
   <td>500</td>
 </tr>
 <tr>
-  <td><code>routes.total_reserved_ports</code></td>
+  <td><code>total_reserved_ports</code></td>
   <td>Total number of ports that are reservable by routes in an organization.</td>
   <td>An integer not greater than <code>routes.total_routes</code></td>
   <td>60</td>
 </tr>
 <tr>
-  <td><code>domains.total_domains</code></td>
+  <td><code>total_domains</code></td>
   <td>Total number of domains that can be scoped to an organization.</td>
   <td>An integer</td>
   <td>6</td>
 </tr>
 <tr>
-  <td><code>relationships.organizations</code></td>
+  <td><code>organizations</code></td>
   <td>A relationship to the organizations where the quota is applied.</td>
-  <td>A list of organization guids</code></td>
-  <td>"data": [
-          { "guid": "9b370018-c38e-44c9-86d6-155c76801104" },
-          { "guid": "9b370018-c38e-44c9-86d6-155c76801104" }
-        ]</td>
+  <td>A list of organization guids</td>
+  <td>9b370018-c38e-44c9-86d6-155c76801104, 12370033-458e-44c2-12d6-789c76801005</td>
 </tr>
 <tr>
   <td><code>trial_db_allowed</code></td>

--- a/quota-plans.html.md.erb
+++ b/quota-plans.html.md.erb
@@ -43,59 +43,90 @@ _Configuring Container-to-Container Networking_.
 </thead>
 <tr>
   <td><code>name</code></td>
-  <td>The name used identify the plan</td>
+  <td>The name used to identify the plan</td>
   <td>A sequence of letters, digits, and underscore characters. Quota plan names within an account must be unique.</td>
   <td>silver_quota</td>
 </tr>
 <tr>
-  <td><code>memory_limit</code></td>
-  <td>The maximum amount of memory usage allowed</td>
-  <td>An integer and a unit of measurement such as M, MB, G, or GB</td>
-  <td>2048&nbsp;M</td>
+  <td><code>apps.total_memory_in_mb</code></td>
+  <td>Total memory allowed for all the started processes and running tasks in an organization</td>
+  <td>An integer</td>
+  <td>2048</td>
 </tr>
 <tr>
-  <td><code>app_instance_limit</code></td>
-  <td>The maximum number of app instances allowed. Stopped apps do not count toward this instance limit. Crashed apps count toward the limit, because their
-    desired state is <code>starting</code>.</td>
+  <td><code>apps.total_instances</code></td>
+  <td>Total instances of all the started processes allowed in an organization.</td>
   <td>An integer</td>
   <td>25</td>
 </tr>
 <tr>
-  <td><code>non_basic_services_allowed</code></td>
-  <td>Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When set to <code>false</code>, non-free
-    service plans can be visible in the marketplace but instances cannot be provisioned.</td>
+  <td><code>apps.per_process_memory_in_mb</code></td>
+  <td>Maximum memory for a single process or task</td>
+  <td>An integer</td>
+  <td>2048</td>
+</tr>
+<tr>
+  <td><code>apps.log_rate_limit_in_bytes_per_second</code></td>
+  <td>Total log rate limit allowed for all the started processes and running tasks in an organization</td>
+  <td>An integer</td>
+  <td>1024</td>
+</tr>
+<tr>
+  <td><code>apps.per_app_tasks</code></td>
+  <td>Maximum number of running tasks in an organization</td>
+  <td>An integer</td>
+  <td>5</td>
+</tr>
+<tr>
+  <td><code>services.paid_services_allowed</code></td>
+  <td>Specifies whether instances of paid service plans can be created.</td>
   <td><code>true</code> or <code>false</code></td>
   <td>true</td>
 </tr>
 <tr>
-  <td><code>total_routes</code></td>
-  <td>The maximum number of routes allowed.</td>
+  <td><code>services.total_service_instances</code></td>
+  <td>Total number of service instances allowed in an organization.</td>
+  <td>An integer</td>
+  <td>10</td>
+</tr>
+<tr>
+  <td><code>services.total_service_keys</code></td>
+  <td>Total number of service keys allowed in an organization.</td>
+  <td>An integer</td>
+  <td>20</td>
+</tr>
+<tr>
+  <td><code>routes.total_routes</code></td>
+  <td>Total number of routes allowed in an organization.</td>
   <td>An integer</td>
   <td>500</td>
 </tr>
 <tr>
-  <td><code>total_reserved_route_ports</code></td>
-  <td>The maximum number of routes with reserved ports.</td>
-  <td>An integer not greater than <code>total_routes</code></td>
+  <td><code>routes.total_reserved_ports</code></td>
+  <td>Total number of ports that are reservable by routes in an organization.</td>
+  <td>An integer not greater than <code>routes.total_routes</code></td>
   <td>60</td>
 </tr>
 <tr>
-  <td><code>total_services</code></td>
-  <td>The maximum number of services allowed.</td>
+  <td><code>domains.total_domains</code></td>
+  <td>Total number of domains that can be scoped to an organization.</td>
   <td>An integer</td>
-  <td>25</td>
+  <td>6</td>
+</tr>
+<tr>
+  <td><code>relationships.organizations</code></td>
+  <td>A relationship to the organizations where the quota is applied.</td>
+  <td>A list of organization guids</code></td>
+  <td>"data": [
+          { "guid": "9b370018-c38e-44c9-86d6-155c76801104" },
+          { "guid": "9b370018-c38e-44c9-86d6-155c76801104" }
+        ]</td>
 </tr>
 <tr>
   <td><code>trial_db_allowed</code></td>
   <td>This is a legacy field. Value can be ignored.</td>
   <td><code>true</code> or <code>false</code></td>
   <td>true</td>
-</tr>
-<tr>
-  <td><code>log_rate_limit</code></td>
-  <td>The maximum number in bytes of logs allowed per second.</td>
-  <td>An integer and a unit of measurement such as K, KB, M, MB, G, or GB</td>
-  <td>2048&nbsp;M</td>
 </tr>
 </table>
 


### PR DESCRIPTION
The Org quota plan attributes in the cloudfoundry documentation were not in line with the organization quota object from the [v3-apidocs](https://v3-apidocs.cloudfoundry.org/version/3.152.0/#organization-quotas). Updating the documentation to actual status.