### PR TITLE
Clarify that CF runs Docker images, not containers

### DIFF
--- a/docker.html.md.erb
+++ b/docker.html.md.erb
@@ -10,18 +10,18 @@ owner: Diego
 
 <% end %>
 
-You can activate Docker support so <%= vars.app_runtime_abbr %> can deploy and manage apps running in Docker containers.
+You can activate Docker support so <%= vars.app_runtime_abbr %> can deploy and manage apps based on Docker container images.
 
 For information about Diego, the <%= vars.app_runtime_first %> component that manages app containers, see
 [Diego Components and Architecture](../concepts/diego/diego-architecture.html). For information about how <%= vars.app_runtime_abbr %> developers push apps with Docker images, see [Deploying an App with Docker](../devguide/deploy-apps/push-docker.html).
 
 
-## <a id='enable'></a> Activate Docker
+## <a id='enable'></a> Activate Docker image support
 
-By default, apps deployed with the `cf push` command run in standard <%= vars.app_runtime_abbr %> Linux containers. With Docker
-support activated, <%= vars.app_runtime_abbr %> can also deploy and manage apps running in Docker containers.
+By default, apps deployed with the `cf push` command run in <%= vars.app_runtime_abbr %> containers based on standard filesystems that come bundled with <%= vars.platform_code %>. With Docker
+support activated, <%= vars.app_runtime_abbr %> can also deploy and manage apps based on Docker container images.
 
-To deploy apps to Docker, developers run `cf push` with the `--docker-image` option and the location of a Docker image to create the containers from. For information about how <%= vars.app_runtime_abbr %> developers push apps with Docker images, see [Push a Docker Image](../devguide/deploy-apps/push-docker.html).
+To deploy Docker-image-based apps, developers run `cf push` with the `--docker-image` option and the location of a Docker image from which to create the containers. For information about how <%= vars.app_runtime_abbr %> developers push apps with Docker images, see [Push a Docker Image](../devguide/deploy-apps/push-docker.html).
 
 To activate Docker support on a <%= vars.app_runtime_abbr %> deployment, you must:
 
@@ -29,28 +29,30 @@ To activate Docker support on a <%= vars.app_runtime_abbr %> deployment, you mus
 
 * Configure access to any Docker registries that you want to use images from.
 
+Configuring these properties requires admin-level access to the <%= vars.app_runtime_abbr %> deployment, and cannot be done by individual app developers.
+
 ### <a id='feature-flag'></a> Enable and deactivate the diego_docker feature flag
 
-The `diego_docker` feature flag governs whether a <%= vars.app_runtime_abbr %> deployment supports Docker containers.
+The `diego_docker` feature flag governs whether a <%= vars.app_runtime_abbr %> deployment supports Docker-image-based containers.
 
-To activate Docker support, run:
+To activate Docker image support, run:
 
 ```
 cf enable-feature-flag diego_docker
 ```
 
-To deactivate Docker support, run:
+To deactivate Docker image support, run:
 
 ```
 cf disable-feature-flag diego_docker
 ```
 
 <p> Deactivating the <code>diego_docker</code> feature flag stops
-all Docker based apps in your deployment within a few convergence cycles, on the order of a one minute.</p>
+all Docker-image-based apps in your deployment within a few convergence cycles, on the order of a one minute.</p>
 
 ### <a id='access-registry'></a> Configure Docker registry access
 
-To support Docker, <%= vars.app_runtime_abbr %> needs the ability to access Docker registries
+To support Docker-image-based apps, <%= vars.app_runtime_abbr %> needs the ability to access Docker registries
 using either a Certificate Authority or an IP address allow list. For information about
 configuring this access, see [Installing Certificates on VMs](https://bosh.io/docs/trusted-certs/).
 
@@ -79,7 +81,7 @@ When creating a container, both Docker and Garden-runC:
 
 These actions produce a container whose contents exactly match the contents of the associated Docker image.
 
-For earlier versions of Diego used Garden-Linux, see [Garden](../concepts/architecture/garden.html).
+For earlier versions of Diego using Garden-Linux, see [Garden](../concepts/architecture/garden.html).
 
 
 ## <a id='run-monitor'></a> How Diego runs and monitors processes
@@ -105,11 +107,11 @@ custom start command or custom environment variables.</p>
 
 ## <a id='multi-tenant'></a> Docker security concerns in a multi-tenant environment
 
-The attack surface area for a Docker based container that runs on Diego remains somewhat higher than that of a buildpack app
+The attack surface area for a Docker-image-based container that runs on Diego remains somewhat higher than that of a buildpack app
 because Docker allows you to fully specify the contents of your root file systems. A buildpack app runs on a trusted root filesystem.
 
 Garden-runC provides features that allow the platform to run Docker images more securely in a multitenant context. In
-particular, <%= vars.app_runtime_abbr %> uses the `user-namespacing` feature found on modern Linux kernels to ensure that users
+particular, <%= vars.app_runtime_abbr %> uses the "user-namespacing" feature found on modern Linux kernels to ensure that users
 cannot gain escalated privileges on the host even if they escalate privileges within a container.
 
 The Cloud Controller always runs Docker containers on Diego with user namespaces enabled. This security restriction


### PR DESCRIPTION
This docs page mentions Cloud Foundry running Docker containers, but Cloud Foundry actually runs Docker container images in Garden containers. This revision intends to clarify that apps can run based on Docker container images and to avoid misleading app developers and platform engineers into thinking that the Docker container engine is running containers within the platform.