### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/_lock_buildpack.html.md.erb
+++ b/_lock_buildpack.html.md.erb
@@ -16,4 +16,4 @@ cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK] [--enable|--dis
 If you are using cf CLI v6, the <code>--rename</code> flag is not supported. Use the
 <code>cf rename-buildpack</code> instead.</p>
 
-This feature is also available through the API. See [Lock or unlock a Buildpack](https://apidocs.cloudfoundry.org/1.24.0/buildpacks/lock_or_unlock_a_buildpack.html) in the [Cloud Foundry API](https://apidocs.cloudfoundry.org/) documentation.
+This feature is also available through the API. See the `locked` flag under [Update a Buildpack](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#update-a-buildpack) in the [Cloud Foundry API](https://apidocs.cloudfoundry.org/) documentation.


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)