### PR TITLE
Web socket support was implemented

### DIFF
--- a/supporting-websockets.html.md.erb
+++ b/supporting-websockets.html.md.erb
@@ -42,16 +42,6 @@ To form a WebSocket connection, the client sends an HTTP request that contains a
 Regardless of your IaaS and configuration, you must configure your load balancer to send the X-Forwarded-For and X-Forwarded-Proto headers for non-WebSocket HTTP requests on ports 80 and 443. For more information, see <a href="https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/securing-traffic.html
 ">Securing Traffic into TAS for VMs</a>.
 
-Gorouter rejects WebSockets requests for routes that are bound to route services.
-These requests return a 503 error and a <code>X-Cf-Routererror
- route_service_unsupported</code> header.
-
- <p class="note">
- Gorouter does not support WebSockets over HTTP/2.
- For more information, see <a href='https://datatracker.ietf.org/doc/html/rfc8441'>RFC 8441</a>.
- Configure your load balancer to always send WebSocket requests to Gorouter over HTTP/1.1.
- For more information, see <a href='./supporting-http2.html#load-balancer'>Configuring HTTP/2 Support</a>.</p>
-
 ## <a id='modify'></a> Setting your Loggregator port
 
 <% if vars.platform_code == 'CF' %>

--- a/supporting-websockets.html.md.erb
+++ b/supporting-websockets.html.md.erb
@@ -42,6 +42,8 @@ To form a WebSocket connection, the client sends an HTTP request that contains a
 Regardless of your IaaS and configuration, you must configure your load balancer to send the X-Forwarded-For and X-Forwarded-Proto headers for non-WebSocket HTTP requests on ports 80 and 443. For more information, see <a href="https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/securing-traffic.html
 ">Securing Traffic into TAS for VMs</a>.
 
+Gorouter supports WebSockets requests for routes that are bound to route services (routing-release version 0.339.0).
+
 ## <a id='modify'></a> Setting your Loggregator port
 
 <% if vars.platform_code == 'CF' %>


### PR DESCRIPTION
[WebSocket Support for Apps with Route-Services](https://github.com/cloudfoundry/routing-release/pull/474)

HTTP2 is also supported in the meantime