### PR TITLE
Document --lifecycle flag for buildpack admin commands (cf CLI v8.14.0)

### DIFF
--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -36,7 +36,7 @@ To add a buildpack:
 1. Run:
 
     ```
-    cf create-buildpack BUILDPACK PATH POSITION
+    cf create-buildpack BUILDPACK PATH POSITION [--lifecycle LIFECYCLE]
     ```
 
     Where:
@@ -45,6 +45,7 @@ To add a buildpack:
       <li><code>PATH</code> specifies the location of the buildpack. <code>PATH</code> can point to a ZIP file, the URL of a ZIP file, or a local
       directory.</li>
       <li><code>POSITION</code> specifies where to place the buildpack in the detection priority list.</li>
+      <li><code>--lifecycle LIFECYCLE</code> (optional) specifies the lifecycle type for the buildpack. Valid values are <code>buildpack</code> (the default, for traditional Cloud Foundry buildpacks) and <code>cnb</code> (for Cloud Native Buildpacks). For more information about Cloud Native Buildpacks, see the <a href="https://buildpacks.io/">Cloud Native Buildpacks documentation</a>.</li>
     </ul>
 
     For more information, enter `cf help create-buildpack`.
@@ -52,15 +53,17 @@ To add a buildpack:
 2. To confirm that you have successfully added a buildpack, run:
 
     ```
-    cf buildpacks
+    cf buildpacks [--lifecycle LIFECYCLE]
     ```
+
+    Use `--lifecycle cnb` to list only Cloud Native Buildpacks, or `--lifecycle buildpack` to list only traditional buildpacks.
 
 ## <a id="update"></a> Update a buildpack
 
 To update a buildpack, run:
 
 ```console
-cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK][--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
+cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK][--enable|--disable] [--lock|--unlock] [--rename NEW_NAME] [--lifecycle LIFECYCLE]
 ```
 
 Where:
@@ -69,6 +72,7 @@ Where:
 * `PATH` is the location of the buildpack.
 * `POSITION` is where the buildpack is in the detection priority list.
 * `STACK` is the stack that the buildpack uses.
+* `--lifecycle LIFECYCLE` (optional) specifies the lifecycle type of the buildpack to update. Valid values are `buildpack` and `cnb`. Use this flag when a traditional buildpack and a Cloud Native Buildpack share the same name to disambiguate which one to update.
 
 For more information about updating buildpacks, enter `cf help update-buildpack`.
 
@@ -77,13 +81,14 @@ For more information about updating buildpacks, enter `cf help update-buildpack`
 To delete a buildpack, run:
 
 ```console
-cf delete-buildpack BUILDPACK [-s STACK] [-f]
+cf delete-buildpack BUILDPACK [-s STACK] [-f] [--lifecycle LIFECYCLE]
 ```
 
 Where:
 
 * `BUILDPACK` is the buildpack name.
 * `STACK` is the stack that the buildpack uses.
+* `--lifecycle LIFECYCLE` (optional) specifies the lifecycle type of the buildpack to delete. Valid values are `buildpack` and `cnb`. Use this flag when a traditional buildpack and a Cloud Native Buildpack share the same name to disambiguate which one to delete.
 
 For more information about deleting buildpacks, enter `cf help delete-buildpack`.
 


### PR DESCRIPTION
## Summary

Updates uildpacks.html.md.erb to document the --lifecycle flag added to buildpack admin commands in cf CLI v8.14.0 (May 2025).

The --lifecycle flag is available on cf create-buildpack, cf update-buildpack, cf delete-buildpack, and cf buildpacks. It specifies the lifecycle type of the buildpack (uildpack for traditional Cloud Foundry buildpacks, cnb for Cloud Native Buildpacks) and is required to disambiguate when a traditional buildpack and a CNB share the same name.

## Test plan

- [ ] Verify each command's usage line shows --lifecycle as an optional flag
- [ ] Verify the cf buildpacks --lifecycle filter example renders correctly
- [ ] Verify the link to the Cloud Native Buildpacks documentation resolves