### PR TITLE
[TNZ-95042] Fix stale Tanzu cf CLI v10 references in buildpacks and cli-user-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ This branch is published through the [docs-book-application-service](https://git
 
 ## Branch map
 
-| Branch  | TPCF version  | Doc Link      |
-|---------|---------------|---------------|
-| 10.5    | EAR 10.5      | TBD |
-| tcf-103 | EAR 10.4      | [EAR v10.4 - staging](https://author-techdocs2-prod.adobecqms.net/content/broadcom/techdocs/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
-| tcf-103 | EAR 10.3      | [EAR v10.3](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
-| tcf-102 | TPCF 10.2     | [TPCF v10.2](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-2/eart/concepts-overview.html) |
-| tcf-10  | TPCF 10.0     | archived PDF |
-| TAS-6.0 | TAS 6.0       | [TAS v6.0](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/6-0/eart/concepts-overview.html) |
-| TAS-5.0 | TAS 5.0       | archived PDF |
-| 22.0    | TAS 4.0       | archived PDF |
+| Branch  | EART version     | Doc Link      |
+|---------|------------------|---------------|
+| 10.5    | EART 10.5        | [EART v10.5 staging](https://author-techdocs2-prod.adobecqms.net/us/en/vmware-tanzu/platform/elastic-application-runtime/10-5/eart/runtime-rn.html)
+| tcf-104 | EART 10.4        | [EART v10.4](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-4/eart/runtime-rn.html)
+| tcf-103 | EART 10.3        | [EART v10.3](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
+| tcf-102 | TPCF 10.2        | [TPCF v10.2](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-2/eart/concepts-overview.html) |
+| tcf-10  | TPCF 10.0        | archived PDF |
+| 6.0     | TAS 6.0          | [TAS v6.0](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/6-0/eart/concepts-overview.html) |
+| 5.0     | TAS 5.0 (EOGS)   | archived PDF  |
+| 4.0     | TAS v4.0 (EOGS)  | archived PDF  |
+| 3.0     | TAS v3.0 (EOGS)  | archived PDF  |
+| 2.13    | TAS v2.13 (EOGS) | archived PDF  |
+| 2.12    | TAS v2.12 (EOGS) | archived PDF  |
+| 2.11    | TAS v2.11 (EOGS) | archived PDF  |

--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -34,18 +34,18 @@ To add a buildpack:
 1. Run:
 
     ```
-    cf create-buildpack BUILDPACK PATH POSITION
+    cf create-buildpack BUILDPACK PATH POSITION [--lifecycle buildpack|cnb]
     ```
 
     Where:
     <ul>
       <li><code>BUILDPACK</code> specifies the buildpack name.</li>
-      <li><code>PATH</code> specifies the location of the buildpack. <code>PATH</code> can point to a ZIP file, the URL of a ZIP file, or a local
-      directory.</li>
+      <li><code>PATH</code> specifies the location of the buildpack. For the <code>buildpack</code> lifecycle, <code>PATH</code> can point to a ZIP file, the URL of a ZIP file, or a local directory. For the <code>cnb</code> lifecycle, <code>PATH</code> should be a CNB file or a gzipped OCI image.</li>
       <li><code>POSITION</code> specifies where to place the buildpack in the detection priority list.</li>
+      <li><code>--lifecycle</code> specifies the lifecycle type: <code>buildpack</code> (default) or <code>cnb</code> for Cloud Native Buildpacks.</li>
     </ul>
 
-    For more information, enter `cf help create-buildpack`.
+    For more information, see the [cf create-buildpack](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/create-buildpack.html) reference.
 
 2. To confirm that you have successfully added a buildpack, run:
 
@@ -53,12 +53,20 @@ To add a buildpack:
     cf buildpacks
     ```
 
+    To filter by lifecycle type, use the `--lifecycle` flag:
+
+    ```
+    cf buildpacks --lifecycle cnb
+    ```
+
+    For more information, see the [cf buildpacks](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/buildpacks.html) reference.
+
 ## <a id="update"></a> Update a buildpack
 
 To update a buildpack, run:
 
 ```console
-cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK][--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
+cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK] [-l LIFECYCLE] [--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
 ```
 
 Where:
@@ -67,25 +75,27 @@ Where:
 * `PATH` is the location of the buildpack.
 * `POSITION` is where the buildpack is in the detection priority list.
 * `STACK` is the stack that the buildpack uses.
+* `LIFECYCLE` is the lifecycle type (`buildpack` or `cnb`), used to disambiguate buildpacks with the same name.
 
 To rename the buildpack, use the <code>cf rename-buildpack</code> command.
 
-For more information about updating buildpacks, enter `cf help update-buildpack`.
+For more information, see the [cf update-buildpack](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/update-buildpack.html) reference.
 
 ## <a id="delete"></a> Delete a buildpack
 
 To delete a buildpack, run:
 
 ```console
-cf delete-buildpack BUILDPACK [-s STACK] [-f]
+cf delete-buildpack BUILDPACK [-s STACK] [-l LIFECYCLE] [-f]
 ```
 
 Where:
 
 * `BUILDPACK` is the buildpack name.
-* `STACK` is the stack that the buildpack uses.
+* `STACK` is the stack that the buildpack uses. Required when the buildpack name is ambiguous.
+* `LIFECYCLE` is the lifecycle type (`buildpack` or `cnb`), used to disambiguate buildpacks with the same name. Required when the buildpack name is ambiguous.
 
-For more information about deleting buildpacks, enter `cf help delete-buildpack`.
+For more information, see the [cf delete-buildpack](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/delete-buildpack.html) reference.
 
 ## <a id="lock"></a> Lock and unlock a buildpack
 

--- a/cli-user-management.html.md.erb
+++ b/cli-user-management.html.md.erb
@@ -103,7 +103,9 @@ Valid [org roles](../concepts/roles.html#roles) are OrgManager, BillingManager, 
 </table>
 
 If multiple accounts share a username, `set-org-role` and `unset-org-role` return an error. See
-[Identical Usernames in Multiple Origins](../operating/cf-cli/getting-started.html#multi-origin) for details.
+[Identical Usernames in Multiple Origins](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/getting-started.html#multi-origin) for details.
+
+You can also assign org and space roles to external user groups from an identity provider (IdP) using the `--user-group` flag with `cf set-org-role` and `cf set-space-role`. For more information, see [Assigning roles to user groups](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/user-group-roles.html).
 
 ### <a id='space-roles'></a>App space roles
 
@@ -142,4 +144,4 @@ Valid [app space roles](../concepts/roles.html#roles) are SpaceManager, SpaceDev
 </table>
 
 If multiple accounts share a username, `set-space-role` and `unset-space-role` return an error. See
-[Identical Usernames in Multiple Origins](../operating/cf-cli/getting-started.html#multi-origin) for details.
+[Identical Usernames in Multiple Origins](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/getting-started.html#multi-origin) for details.


### PR DESCRIPTION
## Summary

- `buildpacks.html.md.erb`: add `--lifecycle buildpack|cnb` flag to `cf create-buildpack`, `cf buildpacks`, `cf update-buildpack`, `cf delete-buildpack` with links to Tanzu cf CLI reference pages
- `cli-user-management.html.md.erb`: fix stale `../operating/cf-cli/getting-started.html#multi-origin` links to external Tanzu cf CLI doc set URL
- `cli-user-management.html.md.erb`: add cross-reference to user-group-roles topic for assigning roles to external IdP user groups via `--user-group` flag

## Test plan
- Verify `--lifecycle` flag syntax matches Tanzu cf CLI v10 command reference
- Verify external links (tanzu-cf-cli doc set) resolve on 10.5 build
- Verify user-group-roles cross-reference is accurate