### PR TITLE
[TNZ-95042] Fix stale Tanzu cf CLI v10 references in buildpacks and cli-user-management (tcf-104)

### DIFF
--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -34,31 +34,33 @@ To add a buildpack:
 1. Run:
 
     ```
-    cf create-buildpack BUILDPACK PATH POSITION
+    cf create-buildpack BUILDPACK PATH POSITION [--lifecycle buildpack|cnb]
     ```
 
     Where:
     <ul>
       <li><code>BUILDPACK</code> specifies the buildpack name.</li>
-      <li><code>PATH</code> specifies the location of the buildpack. <code>PATH</code> can point to a ZIP file, the URL of a ZIP file, or a local
-      directory.</li>
+      <li><code>PATH</code> specifies the location of the buildpack. <code>PATH</code> can point to a ZIP file, the URL of a ZIP file, or a local directory. Required for buildpack lifecycle; optional for CNB lifecycle.</li>
       <li><code>POSITION</code> specifies where to place the buildpack in the detection priority list.</li>
+      <li><code>--lifecycle</code> specifies the lifecycle type: <code>buildpack</code> (default) or <code>cnb</code>.</li>
     </ul>
 
-    For more information, enter `cf help create-buildpack`.
+    For more information, see [`cf create-buildpack`](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/create-buildpack.html) in the Tanzu cf CLI documentation.
 
 2. To confirm that you have successfully added a buildpack, run:
 
     ```
-    cf buildpacks
+    cf buildpacks [--lifecycle buildpack|cnb]
     ```
+
+    Use the `--lifecycle` flag to filter results by lifecycle type. For more information, see [`cf buildpacks`](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/buildpacks.html) in the Tanzu cf CLI documentation.
 
 ## <a id="update"></a> Update a buildpack
 
 To update a buildpack, run:
 
 ```console
-cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK][--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
+cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK] [-l LIFECYCLE] [--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
 ```
 
 Where:
@@ -67,25 +69,27 @@ Where:
 * `PATH` is the location of the buildpack.
 * `POSITION` is where the buildpack is in the detection priority list.
 * `STACK` is the stack that the buildpack uses.
+* `-l LIFECYCLE` disambiguates buildpacks when multiple buildpacks share the same name across lifecycle types (`buildpack` or `cnb`).
 
 To rename the buildpack, use the <code>cf rename-buildpack</code> command.
 
-For more information about updating buildpacks, enter `cf help update-buildpack`.
+For more information, see [`cf update-buildpack`](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/update-buildpack.html) in the Tanzu cf CLI documentation.
 
 ## <a id="delete"></a> Delete a buildpack
 
 To delete a buildpack, run:
 
 ```console
-cf delete-buildpack BUILDPACK [-s STACK] [-f]
+cf delete-buildpack BUILDPACK [-s STACK] [-l LIFECYCLE] [-f]
 ```
 
 Where:
 
 * `BUILDPACK` is the buildpack name.
 * `STACK` is the stack that the buildpack uses.
+* `-l LIFECYCLE` disambiguates buildpacks when multiple buildpacks share the same name across lifecycle types (`buildpack` or `cnb`).
 
-For more information about deleting buildpacks, enter `cf help delete-buildpack`.
+For more information, see [`cf delete-buildpack`](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cmds/delete-buildpack.html) in the Tanzu cf CLI documentation.
 
 ## <a id="lock"></a> Lock and unlock a buildpack
 

--- a/cli-user-management.html.md.erb
+++ b/cli-user-management.html.md.erb
@@ -103,7 +103,9 @@ Valid [org roles](../concepts/roles.html#roles) are OrgManager, BillingManager, 
 </table>
 
 If multiple accounts share a username, `set-org-role` and `unset-org-role` return an error. See
-[Identical Usernames in Multiple Origins](../operating/cf-cli/getting-started.html#multi-origin) for details.
+[Identical Usernames in Multiple Origins](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/getting-started.html#multi-origin) for details.
+
+To assign an org role to all users in an external identity provider (IdP) user group at once, use the `--user-group` flag with `cf set-org-role`. For more information, see [Assigning roles to user groups](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/user-group-roles.html) in the Tanzu cf CLI documentation.
 
 ### <a id='space-roles'></a>App space roles
 
@@ -142,4 +144,4 @@ Valid [app space roles](../concepts/roles.html#roles) are SpaceManager, SpaceDev
 </table>
 
 If multiple accounts share a username, `set-space-role` and `unset-space-role` return an error. See
-[Identical Usernames in Multiple Origins](../operating/cf-cli/getting-started.html#multi-origin) for details.
+[Identical Usernames in Multiple Origins](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/getting-started.html#multi-origin) for details.


### PR DESCRIPTION
## Summary

- `buildpacks.html.md.erb`: add `--lifecycle buildpack|cnb` flag to `cf create-buildpack`, `cf buildpacks`, `cf update-buildpack`, `cf delete-buildpack` with links to Tanzu cf CLI reference pages
- `cli-user-management.html.md.erb`: fix stale `../operating/cf-cli/getting-started.html#multi-origin` links to external Tanzu cf CLI doc set URL
- `cli-user-management.html.md.erb`: add cross-reference to user-group-roles topic for assigning roles to external IdP user groups via `--user-group` flag

## Test plan
- Verify `--lifecycle` flag syntax matches Tanzu cf CLI v10 command reference
- Verify external links resolve on tcf-104 build