### PR TITLE
Remove deprecated --rename flag from cf update-buildpack, add rename section

### DIFF
--- a/_lock_buildpack.html.md.erb
+++ b/_lock_buildpack.html.md.erb
@@ -9,6 +9,6 @@ The <code>--lock</code> flag lets you continue to use your existing buildpack ev
 If you elect to use the <code>--unlock</code> flag, your deployment applies to the most recent buildpack when you upgrade <%=vars.platform_name%>.
 
 ```console
-cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK] [--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
+cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK] [--enable|--disable] [--lock|--unlock]
 ```
 This feature is also available through the API. See the `locked` flag under [Update a Buildpack](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#update-a-buildpack) in the [Cloud Foundry API](https://apidocs.cloudfoundry.org/) documentation.

--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -60,7 +60,7 @@ To add a buildpack:
 To update a buildpack, run:
 
 ```console
-cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK][--enable|--disable] [--lock|--unlock] [--rename NEW_NAME]
+cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-s STACK][--enable|--disable] [--lock|--unlock]
 ```
 
 Where:
@@ -71,6 +71,16 @@ Where:
 * `STACK` is the stack that the buildpack uses.
 
 For more information about updating buildpacks, enter `cf help update-buildpack`.
+
+## <a id="rename"></a> Rename a buildpack
+
+To rename a buildpack, run:
+
+```console
+cf rename-buildpack BUILDPACK NEW_NAME
+```
+
+Where `BUILDPACK` is the current buildpack name and `NEW_NAME` is the new name.
 
 ## <a id="delete"></a> Delete a buildpack
 


### PR DESCRIPTION
## Summary

- Removes `[--rename NEW_NAME]` from the `cf update-buildpack` syntax in `buildpacks.html.md.erb` and `_lock_buildpack.html.md.erb`
- The `--rename` flag was removed in cf CLI v7; `cf rename-buildpack` is the replacement
- Adds a new "Rename a buildpack" section to `buildpacks.html.md.erb` documenting `cf rename-buildpack`

Related: cloudfoundry/docs-dev-guide#511

## Test plan

- [ ] Confirm `--rename` no longer appears in `cf update-buildpack` syntax blocks
- [ ] Confirm new `cf rename-buildpack` section is present and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)