### PR TITLE
Remove platform-conditional ERB blocks, keep OSS content [ai-assisted]

### DIFF
--- a/buildpacks.html.md.erb
+++ b/buildpacks.html.md.erb
@@ -3,13 +3,6 @@ title: Managing custom buildpacks in Cloud Foundry
 owner: Buildpacks
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Managing custom buildpacks in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can manage additional buildpacks in <%= vars.app_runtime_abbr %> by using the Cloud Foundry Command Line Interface
 tool (cf CLI).
 

--- a/configure-lb-healthcheck.html.md.erb
+++ b/configure-lb-healthcheck.html.md.erb
@@ -3,13 +3,6 @@ title: Configuring load balancer health checks for Cloud Foundry routers
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Configuring load balancer health checks for", vars.app_runtime_abbr, "routers") %>
-
-<% end %>
-
 You can configure load balancer health checks for <%= vars.app_runtime_abbr %> routers so requests go only to healthy
 router instances.
 
@@ -21,14 +14,9 @@ directly to the <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) rout
 You can configure your load balancer to use either HTTP or HTTPS for checking the health of `gorouter`
 and `tcp_router` processes.
 
-<% if vars.platform_code == 'CF' %>
 To deactivate the HTTP health check endpoints, set the following properties to `false`:
 - The `router.status.enable_nontls_health_checks` property on the `gorouter` job
 - The `tcp_router.enable_nontls_health_checks` property on the `tcp_router` job
-<% else %>
-To disable the HTTP health check endpoints, deselect the **Enable HTTP load balancer health checks** check boxes
-in the **Networking** pane of the <%= vars.app_runtime_abbr %> and <%= vars.segment_runtime_full %> tiles.
-<% end %>
 
 ### <a id="load-balancer-https"></a> Using HTTPS health check endpoints
 
@@ -46,12 +34,10 @@ along with their corresponding port and path:
 * Gorouter (HTTP router): `http://GOROUTER_IP:8080/health`
 * TCP router: `http://TCP_ROUTER_IP:80/health`
 
-<% if vars.platform_code == 'CF' %>
 The preceding configuration assumes the default health check ports for the <%= vars.app_runtime_abbr %> routers. To modify these
 ports, see the following sections.
 
 <%= partial 'go_tcp_routers_health_check_oss' %>
-<% end %>
 
 
 ## <a id="router_upgrade"></a> Set the healthy and unhealthy threshold properties for the Gorouter
@@ -60,11 +46,7 @@ To maintain high availability during upgrades to the Gorouter, each router is up
 highly available environment with multiple routers, each router is shut down, upgraded, and restarted before the next router is
 upgraded. This ensures that any pending HTTP requests passed to the Gorouter are handled correctly.
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'lb_health_check_oss' %>
-<% else %>
-<%= partial "/pcf/core/lb_health_check" %>
-<% end %>
 
 The following table describes the behavior of the load balancer health checks when a router shuts down and is restarted.
 

--- a/delayed-jobs-index.html.md.erb
+++ b/delayed-jobs-index.html.md.erb
@@ -3,13 +3,6 @@ title: Delayed jobs in Cloud Foundry
 owner: CAPI
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Delayed jobs in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 
 The following information is your source for learning about managing delayed jobs in <%= vars.app_runtime_first %>:
 

--- a/docker.html.md.erb
+++ b/docker.html.md.erb
@@ -3,13 +3,6 @@ title: Using Docker in Cloud Foundry
 owner: Diego
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Using Docker in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can activate Docker support so <%= vars.app_runtime_abbr %> can deploy and manage apps based on Docker container images.
 
 For information about Diego, the <%= vars.app_runtime_first %> component that manages app containers, see

--- a/enabling-tcp-routing.html.md.erb
+++ b/enabling-tcp-routing.html.md.erb
@@ -3,13 +3,6 @@ title: Enabling and configuring TCP routing in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Enabling and configuring TCP routing in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can enable TCP routing in <%= vars.app_runtime_abbr %>. Learn about TCP routing and go through the steps of enabling and configuring it.
 
 ## <a id="overview"></a> TCP routing overview
@@ -92,22 +85,8 @@ Skip this step if you have configured DNS to resolve the TCP domain name to an i
 the TCP router. For more information about configuring port reservations, see [Modify TCP
 Port Reservations](#modify-ports).
 
-<% if vars.platform_code != "CF" %>
-
-1. <%= partial "/pcf/core/tcp_port_review" %>
-
-<% else %>
-
 1. <%= partial "../adminguide/tcp_modify_ports" %>
 
-<% end %>
-
-<% if vars.platform_code != "CF" %>
-## <a id="config-tcp"></a> Enable TCP routing
-
-<%= partial "/pcf/core/configure-tcp-routing" %>
-
-<% else %>
 ### <a id="tls-tcp-routes"></a> TLS for TCP Routing
 
 Starting with [cf-deployment v43.0.0](https://github.com/cloudfoundry/cf-deployment),
@@ -131,7 +110,6 @@ To disable TLS for TCP routing without causing TLS route downtime, you must foll
   1. [operations/disable-tls-tcp-routing-stage-2-tcp-router-and-route-emitter.yml](https://github.com/cloudfoundry/cf-deployment/tree/main/operations/disable-tls-tcp-routing-stage-2-tcp-router-and-route-emitter.yml)
   2. [operations/disable-tls-tcp-routing-isolation-segment-stage-2-route-emitter.yml](https://github.com/cloudfoundry/cf-deployment/tree/main/operations/disable-tls-tcp-routing-isolation-segment-stage-2-route-emitter.yml)
   3. [operations/experimental/disable-tls-tcp-routing-windows-stage-2-route-emitter.yml](https://github.com/cloudfoundry/cf-deployment/tree/main/operations/experimental/disable-tls-tcp-routing-windows-stage-2-route-emitter.yml)
-<% end %>
 
 ## <a id="post-deploy"></a> Configure TCP routing after deploying <%= vars.app_runtime_abbr %>
 
@@ -287,9 +265,3 @@ additional ports are in use. For more information, see <a href="https://github.c
 TCP router fails to configure routes when there is a port conflict with a local process</a> in the Routing Release repository on GitHub.
 </p>
 
-<% if vars.platform_code != "CF" %>
-## <a id="disable-tcp"></a> Deactivate TCP routing
-
-<%= partial "/pcf/core/disable-tcp-routing-procedure" %>
-
-<% end %>

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -2,13 +2,6 @@
 title: Administering Cloud Foundry
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Administering", vars.app_runtime_abbr) %>
-
-<% end %>
-
 These topics are your source for learning to administer <%= vars.app_runtime_first %>, including managing the runtime, creating user accounts, modifying quota plans, and managing isolation segments.
 
 See the following topics:

--- a/instance-identity.html.md.erb
+++ b/instance-identity.html.md.erb
@@ -3,7 +3,6 @@ title: Enabling Instance Identity in Cloud Foundry
 owner: Diego
 ---
 
-<% if vars.platform_code == 'CF' %>
 You can enable the Instance Identity system for your <%= vars.app_runtime_abbr %> deployment.
 
 The Instance Identity system provides each app instance with a
@@ -47,9 +46,3 @@ The CA certificate that the Diego Cell rep uses to issue Instance Identity crede
 * The `KeyUsage` must include `KeyCertSign`.
 
 * If the Diego Cell rep is configured with an intermediate CA certificate, the certificate should have either an empty `ExtendedKeyUsage` extension or one with the `any` property.
-
-<% else %>
-
-The information in this topic does not apply in this context. For information about enabling the Instance Identity system in a Cloud Foundry deployment, see [Enabling Instance Identity](https://docs.cloudfoundry.org/adminguide/instance-identity.html) in the Cloud Foundry documentation.
-
-<% end %>

--- a/isolation-segment-index.html.md.erb
+++ b/isolation-segment-index.html.md.erb
@@ -3,13 +3,6 @@ title: Isolation segments in Cloud Foundry
 owner:
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Isolation segments in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 These topics are your source for learning about managing isolation segments in <%= vars.app_runtime_first %>:
 
 * [Managing Isolation Segments](isolation-segments.html)

--- a/isolation-segments.html.md.erb
+++ b/isolation-segments.html.md.erb
@@ -3,24 +3,12 @@ title: Managing Isolation Segments in Cloud Foundry
 owner: CAPI
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Managing Isolation Segments in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 With <%= vars.app_runtime_abbr %>, you can isolate deployment workloads into dedicated resource pools called isolation segments.
 
 ## <a id='overview'></a> Isolation Segments overview
-<% if vars.platform_code == 'CF' %>
 
 To enable isolation segments, an admin can pass in a custom operations file with the BOSH CLI. For the example file used in this topic,
 see the [cf-deployment](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/add-persistent-isolation-segment-diego-cell.yml) repository in GitHub.
-
-<% else %>
-<%= vars.isolation_segments_intro %>
-<% end %>
 
 After an admin creates a new isolation segment, the admin can then create and manage relationships between the orgs and spaces
 of a <%= vars.app_runtime_first %> deployment and the new isolation segment.
@@ -31,7 +19,6 @@ of a <%= vars.app_runtime_first %> deployment and the new isolation segment.
 Target the API endpoint of your deployment with `cf api` and log in with `cf login` before performing the procedures in this topic. <%= vars.api_endpoint_book %>
 
 
-<% if vars.platform_code == 'CF' %>
 ## <a id="segment-manifest"></a> Add an Isolation Segment to your deployment manifest
 
 To add an isolation segment to your deployment manifest:
@@ -55,18 +42,11 @@ To add an isolation segment to your deployment manifest:
       * `BOSH-ENVIRONMENT` is your BOSH environment alias. For more information about creating an environment alias for BOSH v2 or later, see [Environments](https://bosh.io/docs/cli-envs/) in the BOSH documentation.
       * `SYSTEM-DOMAIN` is the system domain of your <%= vars.app_runtime_abbr %> deployment.
       * `CUSTOM-OPS-FILE.yml` is your operations file.
-<% end %>
 
 
 ## <a id="register-an-is"></a> Register an isolation segment
 
 To register an isolation segment in the Cloud Controller database (CCDB), use the cf CLI.
-
-<% if vars.platform_code != 'CF' %>
-
-If you run smoke tests as a post-deploy errand in the Isolation Segment tile, the smoke tests check if your isolation segment is registered in the CCDB. If the isolation segment is not registered, the smoke tests register it in the CCDB. This eliminates the need to manually register an isolation segment with `cf create-isolation-segment`.
-
-<% end %>
 
 To register an isolation segment in the CCDB:
 

--- a/listing-feature-flags.html.md.erb
+++ b/listing-feature-flags.html.md.erb
@@ -3,13 +3,6 @@ title: Using feature flags with Cloud Foundry
 owner: CLI
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Using feature flags with", vars.app_runtime_abbr) %>
-
-<% end %>
-
 With <%= vars.app_runtime_abbr %>, you can set feature flags by using the cf CLI to activate or deactivate the features available to users.
 
 

--- a/metadata.html.md.erb
+++ b/metadata.html.md.erb
@@ -3,13 +3,6 @@ title: Using metadata in Cloud Foundry
 owner: CAPI/CLI
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Using metadata in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can use metadata in <%= vars.app_runtime_abbr %> and gives you instructions for adding, updating, removing, and viewing metadata.
 
 ## <a id="about"></a> About metadata

--- a/notifications.html.md.erb
+++ b/notifications.html.md.erb
@@ -3,13 +3,6 @@ title: Get started with the Notifications Service in Cloud Foundry
 owner: Notifications
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Get started with the Notifications Service in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can use the Notifications Service in <%= vars.app_runtime_abbr %> to create a client, obtain
 a token, register notifications, create a custom template, and send notifications.
 

--- a/platform-index.html.md.erb
+++ b/platform-index.html.md.erb
@@ -3,13 +3,6 @@ title: Managing the runtime in Cloud Foundry
 owner:
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Managing the runtime in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 These topics are your source for information about managing <%= vars.app_runtime_first %>:
 
 * [Stopping and starting virtual machines](start-stop-vms.html).

--- a/quota-plans.html.md.erb
+++ b/quota-plans.html.md.erb
@@ -3,13 +3,6 @@ title: Creating and modifying quota plans in Cloud Foundry
 owner: CAPI
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Creating and modifying quota plans in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 
 You can use quota plans in <%= vars.app_runtime_abbr %>, including creating and modifying quota plans for orgs and spaces.
 
@@ -146,7 +139,6 @@ _Configuring Container-to-Container Networking_.
 
 * Log rate limit: `unlimited`
 
-<% if vars.platform_code == 'CF' %>
 ## <a id='new-org-plan'></a> Create a quota plan for an org
 
 The org manager sets and manages quotas. For more information, see <a href="../concepts/roles.html">Orgs, Spaces,
@@ -206,15 +198,6 @@ To modify the deployment manifest:
 
 Any subsequent updates to the quota in the manifest are not applied to your environment after the initial deploy, even
 though BOSH updates the Cloud Controller instance with new settings.
-<% else %>
-
-## <a id='new-org-plan'></a> Creating a quota plan for an org
-
-The org manager sets and manages quotas. For more information, see <a href="../concepts/roles.html">Orgs, Spaces,
-  Roles, and Permissions</a>.
-
-You must create a quota plan for the org. To create a new quota plan for org, see [Create a Quota Plan for an Org Through the cf CLI](#create-org-quota).
-<% end %>
 
 ### <a id='create-org-quota'></a> Creating a quota plan for an org through the cf CLI
 
@@ -246,8 +229,6 @@ To create a new quota plan for an org through the cf CLI:
 
 ## <a id='modify-org-plan'></a> Modifying a quota plan for an org
 
-<% if vars.platform_code == 'CF' %>
-
 You can modify an existing quota plan for an org in one of two ways:
 
 * Directly modify the manifest for your <%= vars.app_runtime_abbr %> deployment before deploying. For more information, see [Modify a Quota Plan for an Org
@@ -267,8 +248,6 @@ To modify the <%= vars.app_runtime_abbr %> deployment manifest:
 1. Modify the value of the attribute.
 
 1. Save and close the deployment manifest.
-
-<% end %>
 
 ### <a id='update-org-quota'></a> Modify a quota plan for an org through the cf CLI
 

--- a/routing-index.html.md.erb
+++ b/routing-index.html.md.erb
@@ -3,13 +3,6 @@ title: Routing in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Routing in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 These topics are your source for information about managing routes and domains in <%= vars.app_runtime_first %>:
 
 * [Enabling IPv6 for hosted apps](enabling_ipv6.html)

--- a/routing-is.html.md.erb
+++ b/routing-is.html.md.erb
@@ -3,13 +3,6 @@ title: Routing for isolation segments in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Routing for isolation segments in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can configure and manage routing for isolation segments in <%= vars.app_runtime_abbr %> as described in this topic. You can also deploy a set of Gorouters for each isolation segment to handle requests for apps within the segment.
 
 For more information about how isolation segments work, see [Isolation Segments](../concepts/security.html#isolation-segments) in _<%= vars.app_runtime_abbr %> Security_. <%= vars.install_isolation_segments %>
@@ -78,8 +71,6 @@ For more information about networks and subnets in GCP, see [Using Networks and 
 ## <a id='config-networks'></a> Step 2: Configure networks for Gorouters
 
 To configure the subnets with BOSH, use BOSH cloud config subnets. Each subnet in the IaaS must correspond to a BOSH subnet that is labeled with the correct isolation segment. For more information, see [Usage](https://bosh.io/docs/cloud-config.html) in the BOSH documentation.
-
-<% if vars.platform_code == 'CF' %>
 
 These are examples of cloud config for GCP and AWS for the four example subnets described in [Step 1: Create Networks](#create-networks).
 
@@ -236,14 +227,8 @@ networks:
 ```
 
 
-<% else %>
-<%= vars.pcf_networking_is1 %>
-<% end %>
-
-
 ## <a id='config-instance-group'></a> Step 3: Configure additional Gorouters
 
-<% if vars.platform_code == 'CF' %>
 You must edit the BOSH deployment manifest to include an instance group for each set of Gorouters.
 
 The sample BOSH manifest snippet has an additional instance group for the isolated Gorouters, associated with the isolated BOSH AZs. As a result, Gorouter instances are configured with IP addresses from the isolated subnets. For more information about BOSH manifests, see [Deployment Config](https://bosh.io/docs/manifest-v2.html) in the BOSH documentation.
@@ -284,14 +269,9 @@ instance_groups:
   - name: default
 ```
 
-<% else %>
-<%= vars.pcf_networking_is2 %>
-<% end %>
-
 
 ## <a id='add-routers'></a> Step 4: Add Gorouters to load balancer
 
-<% if vars.platform_code == 'CF' %>
 For some IaaSes such as AWS and GCP, the BOSH cloud config and deployment manifest can be used to instruct BOSH to add Gorouters to the IaaS load balancers automatically. For others, operators must assign static IPs to the Gorouters in the manifest and assign these IPs to the load balancers out of band.
 
 To automatically add load balancers to Gorouters, the `vm_extensions` property is available in BOSH manifests. For example:
@@ -321,11 +301,6 @@ vm_extensions:
 The load balancer <code>sample-is1-elb</code> must be created separately.
 
 If necessary, configure a firewall rule to allow traffic from your load balancer to the Gorouters.
-
-
-<% else %>
-<%= vars.pcf_networking_is3 %>
-<% end %>
 
 
 ## <a id='config-dns-lb'> </a> Step 5: Configure DNS and load balancers
@@ -643,7 +618,6 @@ For more information, see [Understanding backend services](https://cloud.google.
 
 ## <a id='sharding-routers-isolation-segment'></a> Sharding Gorouters for isolation segments
 
-<% if vars.platform_code == 'CF' %>
 To provide security guarantees in addition to the firewall rules previously described, an operator can configure sharding of the Gorouter's routing table, resulting in a Gorouter dedicated for an isolation segment having knowledge only of routes for apps in the same isolation segment. The flexibility of the configuration also supports deployment of a Gorouter that is responsible for multiple isolation segments, or that excludes all isolation segments.
 
 ### Configure Gorouters for sharding
@@ -691,12 +665,6 @@ jobs:
 ```
 
 The `router_<%= vars.app_runtime_abbr_lc %>` Gorouter registers all routes that do not have an `isolation_segment` value. The `router_is1` Gorouter only registers routes that have an `isolation_segment` value of `is1`.
-
-<% else %>
-
-<%= partial "/pcf/core/pcf_sharding" %>
-
-<% end %>
 
 
 ## <a id='isolation-segments-metrics'></a> Metrics for Gorouters associated with isolation segments

--- a/securing-traffic.html.md.erb
+++ b/securing-traffic.html.md.erb
@@ -3,13 +3,6 @@ title: Securing incoming traffic in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Securing incoming traffic in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can secure HTTP traffic into your <%= vars.app_runtime_abbr %> deployment with TLS certificates. You can also configure the location
 where your deployment stops TLS depending on your needs and certificate restrictions.
 
@@ -119,10 +112,7 @@ The Gorouter supports both RSA and ECDSA certificates in PEM encoding. In the ca
 
 <%= vars.multiple_certs_gorouter %>
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'ssl_multicerts_gorouter' %>
-<% else %>
-<% end %>
 
 ## <a id="ciphers"></a> TLS cipher suite support
 
@@ -249,15 +239,7 @@ For more information about HTTP headers in <%= vars.app_runtime_abbr %>, see [HT
 
 ### <a id="pass-through"></a> Procedure: Gorouter only
 
-<% if vars.platform_code != "CF" %>
-
-<%= partial "/pcf/core/ssl_termin_gorouter_pcf" %>
-
-<% else %>
-
 <%= partial "ssl_termin_gorouter_oss" %>
-
-<% end %>
 
 ## <a id="lb_term"></a> Stopping TLS at the load balancer only
 
@@ -283,15 +265,7 @@ For more information about HTTP headers in <%= vars.app_runtime_abbr %>, see [HT
 
 ### <a id="lb"></a> Procedure: Load balancer only
 
-<% if vars.platform_code != "CF" %>
-
-<%= partial "/pcf/core/ssl_termin_lb_only_pcf" %>
-
-<% else %>
-
 <%= partial "ssl_termin_lb_only_oss" %>
-
-<% end %>
 
 ## <a id="lb_and_gorouter_term"></a> Terminating TLS at the load balancer and Gorouter
 
@@ -334,12 +308,4 @@ For more information about HTTP headers in <%= vars.app_runtime_abbr %>, see [HT
 
 ### <a id="lb-and-router"></a> Procedure: Load balancer and Gorouter
 
-<% if vars.platform_code != "CF" %>
-
-<%= partial "/pcf/core/ssl_termin_gorouter_lb_pcf" %>
-
-<% else %>
-
 <%= partial "ssl_termin_gorouter_lb_oss" %>
-
-<% end %>

--- a/stack-auditor.html.md.erb
+++ b/stack-auditor.html.md.erb
@@ -3,13 +3,6 @@ title: Using Stack Auditor in Cloud Foundry
 owner: Buildpacks
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Using Stack Auditor in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 Stack Auditor is a cf CLI plug-in that allows you to list apps and their stacks, migrate apps to a new stack, and delete a stack. Learn how to use it on this page.
 
 A typical use for Stack Auditor is migrating a large number of apps to a new stack.

--- a/start-stop-vms.html.md.erb
+++ b/start-stop-vms.html.md.erb
@@ -3,13 +3,6 @@ title: Stopping and starting virtual machines in Cloud Foundry
 owner: BOSH
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Stopping and starting virtual machines in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 You can stop and start the component <%= vars.app_runtime_abbr %> virtual machines that make up your deployment.
 
 This article assumes you are using [BOSH CLI version 2](https://bosh.io/docs/cli-v2.html).
@@ -32,9 +25,7 @@ To shut down all the VMs in your deployment:
 1. Scale down the following jobs to one instance:
    * `consul_server`
    * `mysql`
-   <% if vars.platform_code == 'CF' %>
    * `etcd_tls_server`
-   <% end %>
 
 1. Run the following command for each of the deployments listed in the previous step:
 

--- a/supporting-websockets.html.md.erb
+++ b/supporting-websockets.html.md.erb
@@ -3,13 +3,6 @@ title: Supporting WebSockets in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Supporting WebSockets in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 In this topic, learn how <%= vars.app_runtime_abbr %> uses WebSockets, why use WebSockets in your apps, and how to configure your
 load balancer to support WebSockets.
 
@@ -45,7 +38,6 @@ Gorouter supports WebSockets requests for routes that are bound to route service
 
 ## <a id='modify'></a> Setting your Loggregator port
 
-<% if vars.platform_code == 'CF' %>
 By default, the <%= vars.app_runtime_abbr %> release manifest assigns port 4443 for TCP/WebSocket communications. If you have configured your load balancer to use a port other than 4443 for TCP/WebSocket traffic, you must edit your <%= vars.app_runtime_abbr %> manifest to set the value of `properties.logger_endpoint.port` to the correct port. Locate the following section of your <%= vars.app_runtime_abbr %> manifest and replace `YOUR-WEBSOCKET-PORT` with the appropriate value:
 
 ```
@@ -53,10 +45,3 @@ properties:
   logger_endpoint:
     port: YOUR-WEBSOCKET-PORT
 ```
-
-<% else %>
-<%= vars.supporting_websockets %>
-
-<img alt="Find Loggregator port field underneath the HAProxy Trusted CIDRs." src="./images/loggregator-port.png">
-
-<% end %>

--- a/troubleshooting-router-error-responses.html.md.erb
+++ b/troubleshooting-router-error-responses.html.md.erb
@@ -3,13 +3,6 @@ title: Troubleshooting router error responses in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Troubleshooting router error responses in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 
 Are your 502 errors the result of your infrastructure, <%= vars.app_runtime_abbr %>, or an app? This topic helps you understand and
 debug these errors.
@@ -51,11 +44,7 @@ Some general debugging steps for any issue resulting in 502 errors are as follow
 ### <a id="levels"></a> Levels
 
 The following table describes the log levels supported by Gorouter.
-<% if vars.platform_code == 'CF' %>
 The log level is specified in the configuration YAML file for Gorouter.
-<% else %>
-The log level is set to `debug` and is not configurable.
-<% end %>
 
 <table class="table">
   <thead>
@@ -240,13 +229,9 @@ A stale route occurs when Gorouter contains out-of-date route information for a
 backend app.
 In nearly all cases, stale routes are self correcting.
 
-<% if vars.platform_code == 'CF' %>
 By default, when Gorouter detects that it is sending traffic to the wrong app, it prunes that backend app from its route table and terminates the connection.
 
 To disable this behavior, set `router.backends.enable_tls` to `false` as described in [TLS to apps and other back end services](../concepts/http-routing.html#tls-to-back-end) in _HTTP Routing_.
-<% else %>
-When Gorouter detects that it is sending traffic to the wrong app, it prunes that backend app from its route table and terminates the connection.
-<% end %>
 
 ### <a id="stale-routes"></a> Causes of stale routes
 
@@ -259,11 +244,7 @@ Gorouter still attempts to send traffic to the app.
 You are more likely to have stale routes when the following are true:
 
 - SSL verification is not activated.
-<% if vars.platform_code == 'CF' %>
 - You do not have Diego Release v2.34.0 or later deployed, which contains a fix that sends unregistration messages multiple times.
-<% else %>
-- You are on a version of <%= vars.app_runtime_abbr %> that does not send deregister messages multiple times.
-<% end %>
 - You unmapped a route to an app, but traffic to that route is still being sent to the app.
 
 ### <a id="stale-route-triage"></a> How to locate stale routes

--- a/troubleshooting_slow_requests.html.md.erb
+++ b/troubleshooting_slow_requests.html.md.erb
@@ -3,13 +3,6 @@ title: Troubleshooting slow requests in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Troubleshooting slow requests in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 What part of the <%= vars.app_runtime_abbr %> request flow adds latency to your
 requests? Run the experiments in this topic to find out.
 

--- a/troubleshooting_tcp_routing.html.md.erb
+++ b/troubleshooting_tcp_routing.html.md.erb
@@ -3,13 +3,6 @@ title: Troubleshooting TCP routing in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Troubleshooting TCP routing in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 Are your TCP routing issues related to DNS and load balancer misconfiguration, the TCP routing tier, or the routing subsystem?
 Use the following steps to find out.
 

--- a/user-accounts-index.html.md.erb
+++ b/user-accounts-index.html.md.erb
@@ -3,13 +3,6 @@ title: User accounts and communications in Cloud Foundry
 owner:
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("User accounts and communications in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 These topics are your source for learning about managing user accounts and user communications in <%= vars.app_runtime_abbr %>:
 
 * [Creating and managing users with the cf CLI](cli-user-management.html).

--- a/w3c_tracing.html.md.erb
+++ b/w3c_tracing.html.md.erb
@@ -3,26 +3,11 @@ title: Enabling W3C tracing in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Enabling W3C tracing in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 
 You can use W3C tracing to troubleshoot failures or latency issues in your apps. You can trace requests and responses
 across distributed systems. For more information, see [w3c.org](https://www.w3.org/TR/trace-context/).
 
-<% if vars.platform_code != "CF" %>
-
-<%= partial "/pcf/core/w3c-pcf-config" %>
-
-<% else %>
-
 <%= partial "w3c_oss_config" %>
-
-<% end %>
 
 For more information about how the Gorouter works with HTTP headers and W3C tracing, see [HTTP headers for W3C tracing](../concepts/http-routing.html#w3c-headers) in _HTTP Routing_.
 

--- a/zipkin_tracing.html.md.erb
+++ b/zipkin_tracing.html.md.erb
@@ -3,26 +3,11 @@ title: Enabling Zipkin tracing in Cloud Foundry
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Enabling Zipkin tracing in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 
 You can use Zipkin tracing to troubleshoot failures or latency issues in your apps. You can trace requests and responses
 across distributed systems. For more information, see [Zipkin.io](http://zipkin.io/).
 
-<% if vars.platform_code != "CF" %>
-
-<%= partial "/pcf/core/zipkin-pcf-config" %>
-
-<% else %>
-
 <%= partial "zipkin_oss_config" %>
-
-<% end %>
 
 For more information about how the Gorouter works with HTTP headers and Zipkin tracing, see the [HTTP Headers](../concepts/http-routing.html#http-headers) section of the _HTTP Routing_ topic.
 


### PR DESCRIPTION
This repo is now dedicated to the OSS Cloud Foundry doc set, so the vars.platform_code conditionals that used to vary content between the OSS and commercial builds no longer serve a purpose. Unwraps CF-branch content in place and deletes PCF-only branches/blocks and the "reset page title based on platform type" title-override pattern.